### PR TITLE
Fix memory leak in Record::new()

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -41,7 +41,12 @@ unsafe impl Send for Record {}
 impl Record {
     /// Create an empty BAM record.
     pub fn new() -> Self {
-        let mut inner = unsafe { *htslib::bam_init1() };
+        let mut inner;
+        unsafe {
+            let aux = htslib::bam_init1();
+            inner = *aux;
+            ::libc::free(aux as *mut ::libc::c_void);
+        }
         inner.m_data = 0;
         Record { inner: inner, own: true }
     }


### PR DESCRIPTION
I’ve detected a memory leak in src/bam/records.rs, in the Record::new() function. That code is calling htslib::bam_init1() and copying the allocated memory's contents to the "inner" variable, which will be part of the result. However, it is not freeing the source memory, loosing the pointer to the allocated structure (which is no longer needed).

This pull request fixes the issue.

Thank you!