### PR TITLE
Use raw pointers in BAM record and refactor access to pointers in BCF record.

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -74,7 +74,7 @@ impl Reader {
 
 impl Read for Reader {
     fn read(&self, record: &mut record::Record) -> Result<(), ReadError> {
-        match unsafe { htslib::bam_read1(self.bgzf, &mut record.inner) } {
+        match unsafe { htslib::bam_read1(self.bgzf, record.inner) } {
             -1 => Err(ReadError::NoMoreRecord),
             -2 => Err(ReadError::Truncated),
             -4 => Err(ReadError::Invalid),
@@ -188,7 +188,7 @@ impl IndexedReader {
 impl Read for IndexedReader {
     fn read(&self, record: &mut record::Record) -> Result<(), ReadError> {
         match self.itr {
-            Some(itr) => match itr_next(self.bgzf, itr, &mut record.inner) {
+            Some(itr) => match itr_next(self.bgzf, itr, record.inner) {
                 -1 => Err(ReadError::NoMoreRecord),
                 -2 => Err(ReadError::Truncated),
                 -4 => Err(ReadError::Invalid),
@@ -294,7 +294,7 @@ impl Writer {
     ///
     /// * `record` - the record to write
     pub fn write(&mut self, record: &record::Record) -> Result<(), ()> {
-        if unsafe { htslib::bam_write1(self.f, &record.inner) } == -1 {
+        if unsafe { htslib::bam_write1(self.f, record.inner) } == -1 {
             Err(())
         }
         else {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -18,11 +18,11 @@ use utils;
 macro_rules! flag {
     ($get:ident, $set:ident, $bit:expr) => (
         pub fn $get(&self) -> bool {
-            self.inner.core.flag & $bit != 0
+            self.inner().core.flag & $bit != 0
         }
 
         pub fn $set(&mut self) {
-            self.inner.core.flag |= $bit;
+            self.inner().core.flag |= $bit;
         }
     )
 }
@@ -30,7 +30,7 @@ macro_rules! flag {
 
 /// A BAM record.
 pub struct Record {
-    pub inner: htslib::bam1_t,
+    pub inner: *mut htslib::bam1_t,
     own: bool,
 }
 
@@ -41,104 +41,109 @@ unsafe impl Send for Record {}
 impl Record {
     /// Create an empty BAM record.
     pub fn new() -> Self {
-        let mut inner = unsafe { *htslib::bam_init1() };
-        inner.m_data = 0;
+        let inner = unsafe { htslib::bam_init1() };
+        unsafe { *inner }.m_data = 0;
         Record { inner: inner, own: true }
     }
 
     pub fn from_inner(inner: *mut htslib::bam1_t) -> Self {
-        Record { inner: unsafe { *inner }, own: false }
+        Record { inner: inner, own: false }
     }
 
     fn data(&self) -> &[u8] {
-        unsafe { slice::from_raw_parts(self.inner.data, self.inner.l_data as usize) }
+        unsafe { slice::from_raw_parts(self.inner().data, self.inner().l_data as usize) }
+    }
+
+    #[inline]
+    pub fn inner(&self) -> htslib::bam1_t {
+        unsafe { *self.inner }
     }
 
     /// Get target id.
     pub fn tid(&self) -> i32 {
-        self.inner.core.tid
+        self.inner().core.tid
     }
 
     /// Set target id.
     pub fn set_tid(&mut self, tid: i32) {
-        self.inner.core.tid = tid;
+        self.inner().core.tid = tid;
     }
 
     /// Get position.
     pub fn pos(&self) -> i32 {
-        self.inner.core.pos
+        self.inner().core.pos
     }
 
     /// Set position.
     pub fn set_pos(&mut self, pos: i32) {
-        self.inner.core.pos = pos;
+        self.inner().core.pos = pos;
     }
 
     pub fn bin(&self) -> u16 {
-        self.inner.core.bin
+        self.inner().core.bin
     }
 
     pub fn set_bin(&mut self, bin: u16) {
-        self.inner.core.bin = bin;
+        self.inner().core.bin = bin;
     }
 
     /// Get MAPQ.
     pub fn mapq(&self) -> u8 {
-        self.inner.core.qual
+        self.inner().core.qual
     }
 
     /// Set MAPQ.
     pub fn set_mapq(&mut self, mapq: u8) {
-        self.inner.core.qual = mapq;
+        self.inner().core.qual = mapq;
     }
 
     /// Get raw flags.
     pub fn flags(&self) -> u16 {
-        self.inner.core.flag
+        self.inner().core.flag
     }
 
     /// Set raw flags.
     pub fn set_flags(&mut self, flags: u16) {
-        self.inner.core.flag = flags;
+        self.inner().core.flag = flags;
     }
 
     /// Unset all flags.
     pub fn unset_flags(&mut self) {
-        self.inner.core.flag = 0;
+        self.inner().core.flag = 0;
     }
 
     /// Get target id of mate.
     pub fn mtid(&self) -> i32 {
-        self.inner.core.mtid
+        self.inner().core.mtid
     }
 
     /// Set target id of mate.
     pub fn set_mtid(&mut self, mtid: i32) {
-        self.inner.core.mtid = mtid;
+        self.inner().core.mtid = mtid;
     }
 
     /// Get mate position.
     pub fn mpos(&self) -> i32 {
-        self.inner.core.mpos
+        self.inner().core.mpos
     }
 
     /// Set mate position.
     pub fn set_mpos(&mut self, mpos: i32) {
-        self.inner.core.mpos = mpos;
+        self.inner().core.mpos = mpos;
     }
 
     /// Get insert size.
     pub fn insert_size(&self) -> i32 {
-        self.inner.core.isize
+        self.inner().core.isize
     }
 
     /// Set insert size.
     pub fn set_insert_size(&mut self, insert_size: i32) {
-        self.inner.core.isize = insert_size;
+        self.inner().core.isize = insert_size;
     }
 
     fn qname_len(&self) -> usize {
-        self.inner.core.l_qname as usize
+        self.inner().core.l_qname as usize
     }
 
     /// Get qname (read name).
@@ -148,25 +153,25 @@ impl Record {
 
     /// Set variable length data (qname, cigar, seq, qual).
     pub fn set(&mut self, qname: &[u8], cigar: &[Cigar], seq: &[u8], qual: &[u8]) {
-        self.inner.l_data = (qname.len() + 1 + cigar.len() * 4 + seq.len() / 2 + qual.len()) as i32;
+        self.inner().l_data = (qname.len() + 1 + cigar.len() * 4 + seq.len() / 2 + qual.len()) as i32;
 
-        if self.inner.m_data < self.inner.l_data {
+        if self.inner().m_data < self.inner().l_data {
 
-            self.inner.m_data = self.inner.l_data;
-            self.inner.m_data += 32 - self.inner.m_data % 32;
+            self.inner().m_data = self.inner().l_data;
+            self.inner().m_data += 32 - self.inner().m_data % 32;
             unsafe {
-                self.inner.data = ::libc::realloc(
-                    self.inner.data as *mut ::libc::c_void, self.inner.m_data as usize
+                self.inner().data = ::libc::realloc(
+                    self.inner().data as *mut ::libc::c_void, self.inner().m_data as usize
                 ) as *mut u8;
             }
         }
 
-        let mut data = unsafe { slice::from_raw_parts_mut(self.inner.data, self.inner.l_data as usize) };
+        let mut data = unsafe { slice::from_raw_parts_mut(self.inner().data, self.inner().l_data as usize) };
         // qname
         utils::copy_memory(qname, data);
         data[qname.len()] = b'\0';
         let mut i = qname.len() + 1;
-        self.inner.core.l_qname = i as u8;
+        self.inner().core.l_qname = i as u8;
 
         // cigar
         {
@@ -176,7 +181,7 @@ impl Record {
             for (i, c) in cigar.iter().enumerate() {
                 cigar_data[i] = c.encode();
             }
-            self.inner.core.n_cigar = cigar.len() as u16;
+            self.inner().core.n_cigar = cigar.len() as u16;
             i += cigar.len() * 4;
         }
 
@@ -185,7 +190,7 @@ impl Record {
             for j in (0..seq.len()).step(2) {
                 data[i + j / 2] = ENCODE_BASE[seq[j] as usize] << 4 | ENCODE_BASE[seq[j + 1] as usize];
             }
-            self.inner.core.l_qseq = seq.len() as i32;
+            self.inner().core.l_qseq = seq.len() as i32;
             i += (seq.len() + 1) / 2;
         }
 
@@ -194,7 +199,7 @@ impl Record {
     }
 
     fn cigar_len(&self) -> usize {
-        self.inner.core.n_cigar as usize
+        self.inner().core.n_cigar as usize
     }
 
     /// Get cigar sequence.
@@ -219,7 +224,7 @@ impl Record {
     }
 
     fn seq_len(&self) -> usize {
-        self.inner.core.l_qseq as usize
+        self.inner().core.l_qseq as usize
     }
 
     /// Get read sequence.
@@ -239,7 +244,7 @@ impl Record {
 
     /// Get auxiliary data (tags).
     pub fn aux(&self, tag: &[u8]) -> Option<Aux> {
-        let aux = unsafe { htslib::bam_aux_get(&self.inner, ffi::CString::new(tag).unwrap().as_ptr() as *mut i8 ) };
+        let aux = unsafe { htslib::bam_aux_get(self.inner, ffi::CString::new(tag).unwrap().as_ptr() as *mut i8 ) };
 
         unsafe {
             if aux.is_null() {
@@ -264,11 +269,11 @@ impl Record {
         let ctag = tag.as_ptr() as *mut i8;
         unsafe {
             match *value {
-                Aux::Integer(v) => htslib::bam_aux_append(&mut self.inner, ctag, b'i' as i8, 4, [v].as_mut_ptr() as *mut u8),
-                Aux::Float(v) => htslib::bam_aux_append(&mut self.inner, ctag, b'f' as i8, 4, [v].as_mut_ptr() as *mut u8),
-                Aux::Char(v) => htslib::bam_aux_append(&mut self.inner, ctag, b'A' as i8, 1, [v].as_mut_ptr() as *mut u8),
+                Aux::Integer(v) => htslib::bam_aux_append(self.inner, ctag, b'i' as i8, 4, [v].as_mut_ptr() as *mut u8),
+                Aux::Float(v) => htslib::bam_aux_append(self.inner, ctag, b'f' as i8, 4, [v].as_mut_ptr() as *mut u8),
+                Aux::Char(v) => htslib::bam_aux_append(self.inner, ctag, b'A' as i8, 1, [v].as_mut_ptr() as *mut u8),
                 Aux::String(v) => htslib::bam_aux_append(
-                    &mut self.inner,
+                    self.inner,
                     ctag,
                     b'Z' as i8,
                     (v.len() + 1) as i32,
@@ -296,7 +301,7 @@ impl Record {
 impl Drop for Record {
     fn drop(&mut self) {
         if self.own {
-            unsafe { ::libc::free(self.inner.data as *mut ::libc::c_void) };
+            unsafe { htslib::bam_destroy1(self.inner) };
         }
     }
 }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -29,8 +29,16 @@ impl Record {
         Record { inner: inner, header: ptr::null_mut(), buffer: ptr::null_mut() }
     }
 
+    pub fn inner(&self) -> &htslib::vcf::bcf1_t {
+        unsafe { &*self.inner }
+    }
+
+    pub fn inner_mut(&mut self) -> &mut htslib::vcf::bcf1_t {
+        unsafe { &mut *self.inner }
+    }
+
     pub fn rid(&self) -> Option<u32> {
-        match unsafe { *self.inner }.rid {
+        match self.inner().rid {
             -1  => None,
             rid => Some(rid as u32)
         }
@@ -38,28 +46,28 @@ impl Record {
 
     // 0-based position.
     pub fn pos(&self) -> u32 {
-        unsafe { *self.inner }.pos as u32
+        self.inner().pos as u32
     }
 
 
     pub fn set_pos(&mut self, pos: i32) {
-        unsafe { (*self.inner).pos = pos; }
+        self.inner_mut().pos = pos;
     }
 
     pub fn alleles(&self) -> Vec<&[u8]> {
         unsafe { htslib::vcf::bcf_unpack(self.inner, htslib::vcf::BCF_UN_STR) };
-        let n = unsafe { *self.inner }.n_allele as usize;
-        let dec = unsafe { *self.inner }.d;
+        let n = self.inner().n_allele as usize;
+        let dec = self.inner().d;
         let alleles = unsafe { slice::from_raw_parts(dec.allele, n) };
         (0..n).map(|i| unsafe { ffi::CStr::from_ptr(alleles[i]).to_bytes() }).collect()
     }
 
     pub fn qual(&self) -> f32 {
-        unsafe { *self.inner }.qual
+        self.inner().qual
     }
 
     pub fn set_qual(&mut self, qual: f32) {
-        unsafe { (*self.inner).qual = qual; }
+        self.inner_mut().qual = qual;
     }
 
     /// Get the value of the given info tag.
@@ -68,11 +76,11 @@ impl Record {
     }
 
     pub fn sample_count(&self) -> u32 {
-        unsafe { *self.inner }.n_fmt_n_sample >> 8
+        self.inner().n_fmt_n_sample >> 8
     }
 
     pub fn allele_count(&self) -> u16 {
-        unsafe { *self.inner }.n_allele
+        self.inner().n_allele
     }
 
     /// Get the value of the given format tag for each sample.
@@ -264,8 +272,16 @@ impl<'a> Format<'a> {
         Format { record: record, tag: tag, inner: inner }
     }
 
+    pub fn inner(&self) -> &htslib::vcf::bcf_fmt_t {
+        unsafe { &*self.inner }
+    }
+
+    pub fn inner_mut(&mut self) -> &mut htslib::vcf::bcf_fmt_t {
+        unsafe { &mut *self.inner }
+    }
+
     fn values_per_sample(&self) -> usize {
-        unsafe { (*self.inner).n as usize }
+        self.inner().n as usize
     }
 
     fn data(&mut self, data_type: i32) -> Result<(usize, i32), TagError> {

--- a/src/htslib/sam.rs
+++ b/src/htslib/sam.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
-#![allow(raw_pointer_derive)]
 
 /* manually added */
 // bgzf.h

--- a/src/htslib/vcf.rs
+++ b/src/htslib/vcf.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![allow(raw_pointer_derive)]
 
 
 pub const BCF_HL_FLT: ::libc::c_int = 0;

--- a/src/htslib/vcfutils.rs
+++ b/src/htslib/vcfutils.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(non_snake_case)]
-#![allow(raw_pointer_derive)]
 
 
 use htslib::vcf::{bcf1_t, bcf_hdr_t};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 #[inline]
 pub fn copy_memory(src: &[u8], dst: &mut [u8]) {
     let len_src = src.len();
-    assert!(dst.len() >= len_src);
+    assert!(dst.len() >= len_src, format!("dst len {} < src len {}", dst.len(), src.len()));
     // `dst` is unaliasable, so we know statically it doesn't overlap
     // with `src`.
     unsafe {


### PR DESCRIPTION
This PR converts BAM records to use a pointer to the inner C struct instead of owning it. This avoids an additional copying during construction (which also caused a memory leak that was fixed preliminarily in PR #17). Futher, access to inner in BCF records has been streamlined as well.