### PR TITLE
add support for seek & tell to get virtual offsets ...

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -47,12 +47,13 @@ pub trait Read: Sized {
     /// Return the header.
     fn header(&self) -> &HeaderView;
 
-    // Seek to the give virtual offset in the file
+    // Seek to the given virtual offset in the file
     fn seek(&self, offset: i64) -> Result<(), ReadError> {
         let ret = unsafe { htslib::bgzf_seek(self.bgzf(), offset, libc::SEEK_SET) };
-        match ret { 
-            0 => Ok(()),
-            _ => Err(ReadError::SeekError)
+        if ret == 0 {
+             Ok(())
+        } else {
+            Err(ReadError::SeekError)
         }
     }
 

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -48,12 +48,12 @@ pub trait Read: Sized {
     fn header(&self) -> &HeaderView;
 
     // Seek to the given virtual offset in the file
-    fn seek(&self, offset: i64) -> Result<(), ReadError> {
+    fn seek(&self, offset: i64) -> Result<(), SeekError> {
         let ret = unsafe { htslib::bgzf_seek(self.bgzf(), offset, libc::SEEK_SET) };
         if ret == 0 {
              Ok(())
         } else {
-            Err(ReadError::SeekError)
+            Err(SeekError::Some)
         }
     }
 
@@ -452,12 +452,6 @@ quick_error! {
         }
         NoMoreRecord {
             description("no more record")
-        }
-        FetchError {
-            description("bam fetch failed")
-        }
-        SeekError {
-            description("bam seek failed")
         }
     }
 }

--- a/src/htslib/sam.rs
+++ b/src/htslib/sam.rs
@@ -3,7 +3,52 @@
 
 /* manually added */
 // bgzf.h
-pub enum Struct_BGZF { }
+#[repr(C)]
+pub struct Struct_BGZF {
+    flags1: ::libc::c_uint,
+    flags2: ::libc::c_int,
+    flags3: ::libc::c_uint,
+
+    cache_size: ::libc::c_int,
+    block_length: ::libc::c_int,
+    block_offset: ::libc::c_int,
+
+    block_address: ::libc::c_long,
+    uncompressed_address: ::libc::c_long,
+
+    uncompressed_block: ::libc::c_ulong,
+    compressed_block: ::libc::c_ulong,
+
+    cache: ::libc::c_ulong,
+    fp: ::libc::c_ulong,
+    mt: ::libc::c_ulong,
+    idx: ::libc::c_ulong,
+
+    idx_build_otf: ::libc::c_int,
+
+    gz_stream: ::libc::c_ulong,
+
+/*
+    unsigned errcode:16, is_write:2, is_be:2;
+    signed compress_level:9;
+    unsigned is_compressed:2, is_gzip:1;
+    int cache_size;
+    int block_length, block_offset;
+    int64_t block_address, uncompressed_address;
+    void *uncompressed_block, *compressed_block;
+    void *cache; // a pointer to a hash table
+    struct hFILE *fp; // actual file handle
+    struct bgzf_mtaux_t *mt; // only used for multi-threading
+    bgzidx_t *idx;      // BGZF index
+    int idx_build_otf;  // build index on the fly, set by bgzf_index_build_init()
+    z_stream *gz_stream;// for gzip-compressed files
+*/
+}
+
+pub fn bgzf_tell(fp: *const BGZF) -> ::libc::c_long {
+    unsafe { ((*fp).block_address << 16) | (((*fp).block_offset & 0xFFFF) as ::libc::c_long ) }
+}
+
 pub type BGZF = Struct_BGZF;
 
 extern "C" {
@@ -327,6 +372,7 @@ extern "C" {
 
 extern "C" {
     pub fn bgzf_open(_fn: *const ::libc::c_char, mode: *const ::libc::c_char) -> *mut BGZF;
+    pub fn bgzf_seek(fp: *mut BGZF, pos: int64_t, relative: ::libc::c_int) -> int64_t;
     pub fn hts_version() -> *const ::libc::c_char;
     pub fn hts_detect_format(fp: *mut Struct_hFILE, fmt: *mut htsFormat)
      -> ::libc::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! // seek to chr1:50000-100000
 //! let tid = bam.header.tid(b"CHROMOSOME_I").unwrap();
-//! bam.seek(tid, 0, 20).unwrap();
+//! bam.fetch(tid, 0, 20).unwrap();
 //! // afterwards, read or pileup in this region
 //! ```
 


### PR DESCRIPTION
from the underlying BGZF handle. 

This ties us to the details of the BGZF struct, because bgzf_tell is unfortunately implemented as a macro in htslib, rather than a method.

One question: pysam uses "fetch" for a position-based query, and seek/tell to set/get the virtual offset of a BAM file.  rust-htslib is using the "seek" for a position-based query. This led to the terms seek_voffset / tell_voffset for the new functionality. Wondering if we should reconsider the naming at all?