### PR TITLE
Minor suggestions for CIGAR errors & pos parsing.

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -722,9 +722,13 @@ mod tests {
             assert_eq!(rec.seq().as_bytes(), seqs[i]);
             assert_eq!(*rec.cigar(), cigars[i]);
             let cigar = rec.cigar();
-            assert_eq!(cigar.end_pos(), rec.pos() + 100 + del_len[i]);
+            if let Ok(end_pos) = cigar.end_pos() {
+                assert_eq!( end_pos, rec.pos() + 100 + del_len[i]);
+                assert_eq!(cigar.read_pos( end_pos as u32 - 10, false, false).unwrap().unwrap(), 90);
+            } else {
+                panic!("bug: failed to fetch cigar.end_pos() in test_read()")
+            }
             assert_eq!(cigar.read_pos(rec.pos() as u32 + 20, false, false).unwrap().unwrap(), 20);
-            assert_eq!(cigar.read_pos(cigar.end_pos() as u32 - 10, false, false).unwrap().unwrap(), 90);
             assert_eq!(cigar.read_pos(4000000, false, false).unwrap(), None);
             // fix qual offset
             let qual: Vec<u8> = quals[i].iter().map(|&q| q - 33).collect();

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -492,7 +492,7 @@ impl Cigar {
         }
     }
 
-    /// Return the length the CIGAR.
+    /// Return the length of the CIGAR.
     pub fn len(&self) -> u32 {
         match *self {
             Cigar::Match(len)    => len,

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -633,7 +633,7 @@ impl CigarStringView {
     ///
     /// * `ref_pos` - the reference position
     /// * `include_softclips` - if true, softclips will be considered as matches or mismatches
-    /// * `include_dels` - if true, positions within deletions will be considered (start of deletion will be returned)
+    /// * `include_dels` - if true, positions within deletions will be considered (first reference matching read position after deletion will be returned)
     ///
     pub fn read_pos(
         &self,

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -605,25 +605,22 @@ pub struct CigarStringView {
 
 impl CigarStringView {
     /// Get end position of alignment.
-    pub fn end_pos(&self) -> i32 {
+    pub fn end_pos(&self) -> Result<i32, CigarError> {
         let mut pos = self.pos;
         for c in self {
             match c {
                 &Cigar::Match(l) | &Cigar::RefSkip(l) | &Cigar::Del(l) |
                 &Cigar::Equal(l) | &Cigar::Diff(l) => pos += l as i32,
-                &Cigar::Back(l) => pos -= l as i32, // TODO: Don't we want to consistently deprecate this operation? E.g. by returning the following error (this would require a change of this function's signature!)
-                /*
-                {
+                // these don't add to end_pos on reference
+                &Cigar::Ins(_) | &Cigar::SoftClip(_) | &Cigar::HardClip(_) | &Cigar::Pad(_) => (),
+                &Cigar::Back(_) => {
                     return Err(CigarError::UnsupportedOperation(
                         "'back' (B) operation is deprecated according to htslib/bam_plcmd.c and is not in SAMv1 spec".to_owned()
                     ));
                 }
-                */
-                // these don't add to end_pos on reference
-                &Cigar::Ins(_) | &Cigar::SoftClip(_) | &Cigar::HardClip(_) | &Cigar::Pad(_) => ()
             }
         }
-        pos
+        Ok( pos )
     }
 
     /// For a given position in the reference, get corresponding position within read.

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -611,7 +611,14 @@ impl CigarStringView {
             match c {
                 &Cigar::Match(l) | &Cigar::RefSkip(l) | &Cigar::Del(l) |
                 &Cigar::Equal(l) | &Cigar::Diff(l) => pos += l as i32,
-                &Cigar::Back(l) => pos -= l as i32,
+                &Cigar::Back(l) => pos -= l as i32, // TODO: Don't we want to consistently deprecate this operation? E.g. by returning the following error (this would require a change of this function's signature!)
+                /*
+                {
+                    return Err(CigarError::UnsupportedOperation(
+                        "'back' (B) operation is deprecated according to htslib/bam_plcmd.c and is not in SAMv1 spec".to_owned()
+                    ));
+                }
+                */
                 // these don't add to end_pos on reference
                 &Cigar::Ins(_) | &Cigar::SoftClip(_) | &Cigar::HardClip(_) | &Cigar::Pad(_) => ()
             }


### PR DESCRIPTION
Before deleting the CigarError and CigarString parsing from my libprosic branch, I went over the implementation here and have some minor suggestions to @johanneskoester's implementation here. Mainly:

1. A distinction between `Unsupported` and `Unexpected` Cigar operations.
2. A mixture of our wordings in the CigarError messages.
3. The question whether to support the `Pad` operation, where the SAMv1 spec is not really clear on how it works and where I am not sure if any software uses it...