### PR TITLE
Made CigarStringView more accessible

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -566,6 +566,7 @@ custom_derive! {
 }
 
 impl CigarString {
+    /// Create a `CigarStringView` from this CigarString at position `pos`
     pub fn into_view(self, pos: i32) -> CigarStringView {
         CigarStringView::new(self, pos)
     }


### PR DESCRIPTION
Because I use the cigarstring in a project I need to be able to create the CigarString and the views. I added a few methods to make this more easy:

 * Added into_view to CigarString
 * Added public constructor to CigarStringView

Updated code and tests.