### PR TITLE
Add set_qname and fix a trailing newline created by from_template

### DIFF
--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -19,7 +19,19 @@ impl Header {
     }
 
     pub fn from_template(header: &HeaderView) -> Self {
-        Header { records: vec![header.as_bytes().to_owned()] }
+        let mut record = header.as_bytes().to_owned();
+        // Strip off any trailing newline character.
+        // Otherwise there could be a blank line in the
+        // header which samtools (<=1.6) will complain
+        // about
+        while let Some(&last_char) = record.last() {
+            if last_char==b'\n' {
+                record.pop();
+            } else {
+                break;
+            }
+        }
+        Header { records: vec![record] }
     }
 
     /// Add a record to the header.

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -221,6 +221,8 @@ impl Record {
     }
 
     /// Replace current qname with a new one.
+    /// Unlike set(), this preserves all the variable length data including
+    /// the aux.
     pub fn set_qname(&mut self, new_qname: &[u8]) {
         let old_q_len = self.qname_len();
         // We're going to add a terminal NUL

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -176,7 +176,9 @@ impl Record {
     }
 
     /// Set variable length data (qname, cigar, seq, qual).
-    /// Note: this obliterates aux
+    /// Note: Pre-existing aux data will be invalidated
+    /// if called on an existing record. For this
+    /// reason, never call push_aux() before set().
     pub fn set(&mut self, qname: &[u8], cigar: &CigarString, seq: &[u8], qual: &[u8]) {
         self.inner_mut().l_data = (qname.len() + 1 + cigar.len() * 4 + ((seq.len() as f32 / 2.0).ceil() as usize) + qual.len()) as i32;
 
@@ -218,6 +220,7 @@ impl Record {
         utils::copy_memory(qual, &mut data[i..]);
     }
 
+    /// Replace current qname with a new one.
     pub fn set_qname(&mut self, new_qname: &[u8]) {
         let old_q_len = self.qname_len();
         // We're going to add a terminal NUL
@@ -348,6 +351,7 @@ impl Record {
     }
 
     /// Add auxiliary data.
+    /// push_aux() should never be called before set().
     pub fn push_aux(&mut self, tag: &[u8], value: &Aux) {
         let ctag = tag.as_ptr() as *mut i8;
         unsafe {


### PR DESCRIPTION
Add a set_qname method that permits overwriting the qname without affecting other data.
Also fix a small bug in from_template that leaves a trailing newline in header -- samtools 1.6 doesn't like that.