### PR TITLE
Store bcf header on heap behind Rc pointer.

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -575,7 +575,7 @@ quick_error! {
 
 quick_error! {
     #[derive(Debug)]
-    pub enum PushAuxError {
+    pub enum AuxWriteError {
         Some {
             description("error pushing aux data to record")
         }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -13,7 +13,7 @@ use std::error::Error;
 use itertools::Itertools;
 
 use htslib;
-use bam::{HeaderView, ReadError, PushAuxError};
+use bam::{HeaderView, ReadError, AuxWriteError};
 use utils;
 
 
@@ -396,7 +396,7 @@ impl Record {
 
     /// Add auxiliary data.
     /// push_aux() should never be called before set().
-    pub fn push_aux(&mut self, tag: &[u8], value: &Aux) -> Result<(), PushAuxError> {
+    pub fn push_aux(&mut self, tag: &[u8], value: &Aux) -> Result<(), AuxWriteError> {
         let ctag = tag.as_ptr() as *mut i8;
         let ret = unsafe {
             match *value {
@@ -414,7 +414,7 @@ impl Record {
         };
 
         if ret < 0 {
-            Err(PushAuxError::Some)
+            Err(AuxWriteError::Some)
         } else {
             Ok(())
         }

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -111,7 +111,7 @@ impl RecordBuffer {
 
         // extend to the right
         loop {
-            let mut rec = bcf::Record::new();
+            let mut rec = self.reader.empty_record();
             if let Err(e) = self.reader.read(&mut rec) {
                 if e.is_eof() {
                     break;


### PR DESCRIPTION
 This allows records to share the same header object. Moreover it fixes a dangling pointer (to the header) issue that occured before when a record lives longer than the originating reader. Now the reference counter ensures that the header lives as long as the last existing record.