### PR TITLE
Derive Copy and Clone for GenotypeAllele

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -721,7 +721,7 @@ impl CigarStringView {
         CigarStringView { inner: c, pos: pos }
     }
 
-    /// Get end position of alignment.
+    /// Get (exclusive) end position of alignment.
     pub fn end_pos(&self) -> Result<i32, CigarError> {
         let mut pos = self.pos;
         for c in self {

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -252,7 +252,7 @@ impl Record {
 
 
 /// Phased or unphased alleles, represented as indices.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum GenotypeAllele {
     Unphased(i32),
     Phased(i32),


### PR DESCRIPTION
GenotypeAllele is a simple enum and it is much simpler to work with when it implements Clone and Copy. Would you consider adding it in the next release?

I could also derive other useful traits for simple structs in HTSLib (More Clone, Copy, Eq, Hash, ...) if you are interested. Could make using it easier :-)

Thanks!