### PR TITLE
Extend derives for structs and enums

### DIFF
--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -17,6 +17,7 @@ use bam::Read;
 /// The buffer is implemented as a ringbuffer, such that extension or movement to the right has
 /// linear complexity. The buffer makes use of indexed random access. Hence, when fetching a
 /// region at the very end of the BAM, everything before is omitted without cost.
+#[derive(Debug)]
 pub struct RecordBuffer {
     reader: bam::IndexedReader,
     inner: VecDeque<bam::Record>,
@@ -124,7 +125,7 @@ impl RecordBuffer {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum RecordBufferError {
         UnknownSequence(chrom: String) {
             description("unknown sequence")

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -7,6 +7,7 @@ use bam::HeaderView;
 
 
 /// A BAM header.
+#[derive(Debug, Clone)]
 pub struct Header {
     records: Vec<Vec<u8>>
 }
@@ -53,6 +54,7 @@ impl Header {
 
 
 /// Header record.
+#[derive(Debug, Clone)]
 pub struct HeaderRecord<'a> {
     rec_type: Vec<u8>,
     tags: Vec<(&'a [u8], Vec<u8>)>,

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -72,6 +72,7 @@ pub trait Read: Sized {
 
 
 /// A BAM reader.
+#[derive(Debug)]
 pub struct Reader {
     bgzf: *mut htslib::BGZF,
     header: HeaderView,
@@ -174,6 +175,7 @@ impl Drop for Reader {
 }
 
 
+#[derive(Debug)]
 pub struct IndexedReader {
     bgzf: *mut htslib::BGZF,
     header: HeaderView,
@@ -311,6 +313,7 @@ impl Drop for IndexedReader {
 
 
 /// A BAM writer.
+#[derive(Debug)]
 pub struct Writer {
     f: *mut htslib::BGZF,
     header: HeaderView,
@@ -429,6 +432,7 @@ impl Drop for Writer {
 
 
 /// Iterator over the records of a BAM.
+#[derive(Debug)]
 pub struct Records<'a, R: 'a + Read> {
     reader: &'a mut R
 }
@@ -449,7 +453,7 @@ impl<'a, R: Read> Iterator for Records<'a, R> {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum ReadError {
         Truncated {
             description("truncated record")
@@ -476,7 +480,7 @@ impl ReadError {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum IndexedReaderError {
         InvalidIndex {
             description("invalid index")
@@ -489,7 +493,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum WriterPathError {
         InvalidPath {
             description("invalid path")
@@ -502,7 +506,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum IndexedReaderPathError {
         InvalidPath {
             description("invalid path")
@@ -515,7 +519,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum BGZFError {
         Some {
             description("error reading BGZF file")
@@ -525,7 +529,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum ReaderPathError {
         InvalidPath {
             description("invalid path")
@@ -538,7 +542,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum ThreadingError {
         Some {
             description("error setting threads for multi-threaded writing")
@@ -547,7 +551,7 @@ quick_error! {
 }
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum WriteError {
         Some {
             description("error writing record")
@@ -557,7 +561,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum FetchError {
         Some {
             description("error fetching a locus")
@@ -567,7 +571,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum SeekError {
         Some {
             description("error seeking to voffset")
@@ -577,7 +581,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum AuxWriteError {
         Some {
             description("error pushing aux data to record")
@@ -615,6 +619,7 @@ fn itr_next(bgzf: *mut htslib::BGZF, itr: *mut htslib:: hts_itr_t, record: *mut 
 }
 
 
+#[derive(Debug)]
 pub struct HeaderView {
     inner: *mut htslib::bam_hdr_t,
     owned: bool,

--- a/src/bam/pileup.rs
+++ b/src/bam/pileup.rs
@@ -5,6 +5,7 @@
 
 use std::slice;
 use std::iter;
+use std::fmt;
 
 use htslib;
 
@@ -20,6 +21,7 @@ pub type Alignments<'a> = iter::Map<
 
 
 /// A pileup over one genomic position.
+#[derive(Debug)]
 pub struct Pileup {
     inner: *const htslib::bam_pileup1_t,
     depth: u32,
@@ -54,6 +56,13 @@ impl Pileup {
 /// An aligned read in a pileup.
 pub struct Alignment<'a> {
     inner: &'a htslib::bam_pileup1_t,
+}
+
+
+impl<'a> fmt::Debug for Alignment<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Alignment")
+    }
 }
 
 
@@ -108,8 +117,7 @@ impl<'a> Alignment<'a> {
 }
 
 
-#[derive(PartialEq)]
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Debug, Copy, Clone, Hash)]
 pub enum Indel {
     Ins(u32),
     Del(u32),
@@ -118,6 +126,7 @@ pub enum Indel {
 
 
 /// Iterator over pileups.
+#[derive(Debug)]
 pub struct Pileups<'a, R: 'a + bam::Read> {
     #[allow(dead_code)]
     reader: &'a mut R,
@@ -172,7 +181,7 @@ impl<'a, R: bam::Read> Drop for Pileups<'a, R> {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum PileupError {
         Some {
             description("error generating pileup")

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -51,7 +51,6 @@ quick_error! {
 
 
 /// A BAM record.
-#[derive(Debug)]
 pub struct Record {
     pub inner: *mut htslib::bam1_t,
     own: bool

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -36,7 +36,7 @@ macro_rules! flag {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum CigarError {
         UnsupportedOperation(msg: String) {
             description("Unsupported CIGAR operation")
@@ -51,6 +51,7 @@ quick_error! {
 
 
 /// A BAM record.
+#[derive(Debug)]
 pub struct Record {
     pub inner: *mut htslib::bam1_t,
     own: bool
@@ -498,8 +499,7 @@ impl Drop for Record {
 }
 
 /// Auxiliary record data.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Aux<'a> {
     Integer(i64),
     String(&'a [u8]),
@@ -566,6 +566,7 @@ static ENCODE_BASE: [u8; 256] = [
 
 
 /// The sequence of a record.
+#[derive(Debug, Copy, Clone)]
 pub struct Seq<'a> {
     pub encoded: &'a [u8],
     len: usize
@@ -605,7 +606,7 @@ unsafe impl<'a> Send for Seq<'a> {}
 unsafe impl<'a> Sync for Seq<'a> {}
 
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy, Hash)]
 pub enum Cigar {
     Match(u32),  // M
     Ins(u32),  // I
@@ -707,7 +708,8 @@ custom_derive! {
              PartialEq,
              Eq,
              NewtypeDebug,
-             Clone
+             Clone,
+             Hash
     )]
     pub struct CigarString(pub Vec<Cigar>);
 }

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -16,6 +16,7 @@ use bcf;
 /// linear complexity. The buffer does not use any indexed random access. Hence, for getting a
 /// region at the very end of the BCF, you will have to wait until all records before have
 /// been read.
+#[derive(Debug)]
 pub struct RecordBuffer {
     reader: bcf::Reader,
     ringbuffer: VecDeque<bcf::Record>,

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -15,6 +15,7 @@ pub type SampleSubset = Vec<i32>;
 
 
 /// A BCF header.
+#[derive(Debug)]
 pub struct Header {
     pub inner: *mut htslib::bcf_hdr_t,
     pub subset: Option<SampleSubset>,
@@ -92,7 +93,7 @@ impl Drop for Header {
 }
 
 
-
+#[derive(Debug)]
 pub struct HeaderView {
     pub inner: *mut htslib::bcf_hdr_t,
 }
@@ -200,6 +201,7 @@ impl Drop for HeaderView {
 }
 
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TagType {
     Flag,
     Integer,
@@ -208,6 +210,7 @@ pub enum TagType {
 }
 
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TagLength {
     Fixed,
     AltAlleles,
@@ -218,7 +221,7 @@ pub enum TagLength {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum RidError {
         UnknownSequence(name: String) {
             description("unknown sequence")
@@ -229,7 +232,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum SubsetError {
         DuplicateSampleName {
             description("duplicate sample name when subsetting header")
@@ -239,7 +242,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum TagTypeError {
         UnexpectedTagType {
             description("unexpected tag type in header")

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -22,6 +22,7 @@ pub use bcf::buffer::RecordBuffer;
 
 
 /// A VCF/BCF reader.
+#[derive(Debug)]
 pub struct Reader {
     inner: *mut htslib::htsFile,
     header: Rc<HeaderView>,
@@ -103,6 +104,7 @@ impl Drop for Reader {
 
 
 /// A VCF/BCF writer.
+#[derive(Debug)]
 pub struct Writer {
     inner: *mut htslib::htsFile,
     header: Rc<HeaderView>,
@@ -200,6 +202,7 @@ impl Drop for Writer {
 }
 
 
+#[derive(Debug)]
 pub struct Records<'a> {
     reader: &'a mut Reader,
 }
@@ -220,7 +223,7 @@ impl<'a> Iterator for Records<'a> {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum BCFError {
         Some {
             description("error reading BCF/VCF file")
@@ -230,7 +233,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum BCFPathError {
         InvalidPath {
             description("invalid path")
@@ -260,7 +263,7 @@ fn bcf_open(path: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile, BCFError> 
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum ReadError {
         Invalid {
             description("invalid record")
@@ -284,7 +287,7 @@ impl ReadError {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum WriteError {
         Some {
             description("failed to write record")

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -79,6 +79,7 @@ impl NumericUtils for i32 {
 
 /// A BCF record.
 /// New records can be created by the `empty_record` methods of `bcf::Reader` and `bcf::Writer`.
+#[derive(Debug)]
 pub struct Record {
     pub inner: *mut htslib::bcf1_t,
     header: Rc<HeaderView>,
@@ -252,7 +253,7 @@ impl Record {
 
 
 /// Phased or unphased alleles, represented as indices.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GenotypeAllele {
     Unphased(i32),
     Phased(i32),
@@ -297,7 +298,7 @@ impl fmt::Display for GenotypeAllele {
 
 custom_derive! {
     /// Genotype representation as a vector of `GenotypeAllele`.
-    #[derive(NewtypeDeref, Debug)]
+    #[derive(NewtypeDeref, Debug, Clone, PartialEq, Eq, Hash)]
     pub struct Genotype(Vec<GenotypeAllele>);
 }
 
@@ -321,7 +322,7 @@ impl fmt::Display for Genotype {
 
 
 /// Lazy representation of genotypes, that does no computation until a particular genotype is queried.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Genotypes<'a> {
     encoded: Vec<&'a [i32]>
 }
@@ -357,6 +358,7 @@ unsafe impl Sync for Record {}
 
 
 /// Info tag representation.
+#[derive(Debug)]
 pub struct Info<'a> {
     record: &'a mut Record,
     tag: &'a [u8],
@@ -461,6 +463,7 @@ fn trim_slice<T: PartialEq + NumericUtils>(s: &[T]) -> &[T] {
 
 
 // Representation of per-sample data.
+#[derive(Debug)]
 pub struct Format<'a> {
     record: &'a mut Record,
     tag: &'a [u8],
@@ -575,7 +578,7 @@ unsafe impl<'a> Sync for Format<'a> {}
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum InfoReadError {
         UndefinedTag {
             description("tag undefined in header")
@@ -588,7 +591,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum FormatReadError {
         UndefinedTag {
             description("tag undefined in header")
@@ -604,7 +607,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum TagWriteError {
         Some {
             description("error writing tag to record")
@@ -614,7 +617,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum TrimAllelesError {
         Some {
             description("error trimming alleles")

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -8,6 +8,7 @@ use bam::record;
 use bam::HeaderView;
 
 /// SAM writer.
+#[derive(Debug)]
 pub struct Writer {
     f: *mut htslib::htsFile,
     header: HeaderView,
@@ -86,7 +87,7 @@ impl Drop for Writer {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum WriterError {
         IOError {}
     }
@@ -94,7 +95,7 @@ quick_error! {
 
 
 quick_error! {
-    #[derive(Debug)]
+    #[derive(Debug, Clone)]
     pub enum WriteError {
         Some {
             description("error writing record")


### PR DESCRIPTION
* Add `Debug` for all structs and enums (even structures with only pointers -- it is still useful to auto-derive `Debug` for your struct containing those).
* Add `Clone` / `Copy` for structs & enums with simple data (no pointers, e.g. only `Vec`s, `Option`s, primitives, references).
* Add `PartialEq` / `Eq` and `Hash` to structs with clear semantics (not some seemingly binary-encoded data, there `PartialEq` might not match the data semantics)
* Add `Clone` for errors (not `Copy` in case you would like to extend some them with `String` messages or such)

Would you consider releasing a new version? (my code depends on copying `GenotypeAllele` and it would make my life and code distribution simpler) Thanks!