### PR TITLE
upgrade bindgen 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,4 +34,4 @@ serde_json = "1.0"
 
 [build-dependencies]
 fs-utils = "1.0"
-bindgen = "0.32.1"
+bindgen = "0.35.0"


### PR DESCRIPTION
to get fix to https://github.com/rust-lang-nursery/rust-bindgen/issues/1248
this was causing the rust-htslib build to fail for me.