### PR TITLE
 restore old cigar() api and add cached_cigar() getter

### DIFF
--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -70,7 +70,8 @@ impl RecordBuffer {
         if let Some(tid) = self.reader.header.tid(chrom) {
             let mut deleted = 0;
             let window_start = start;
-            if self.inner.is_empty() || self.end().unwrap() < window_start
+            if self.inner.is_empty()
+                || self.end().unwrap() < window_start
                 || self.tid().unwrap() != tid as i32
                 || self.start().unwrap() > window_start
             {

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -665,10 +665,8 @@ pub struct HeaderView {
 }
 
 impl HeaderView {
-
     /// Create a new HeaderView from a pre-populated Header object
     pub fn from_header(header: &Header) -> Self {
-        
         let mut header_string = header.to_bytes();
         if !header_string.is_empty() && header_string[header_string.len() - 1] != b'\n' {
             header_string.push(b'\n');
@@ -678,7 +676,6 @@ impl HeaderView {
 
     /// Create a new HeaderView from bytes
     pub fn from_bytes(header_string: &[u8]) -> Self {
-
         let header_record = unsafe {
             let l_text = header_string.len();
             let text = ::libc::malloc(l_text + 1);
@@ -689,10 +686,7 @@ impl HeaderView {
                 header_string.len(),
             );
 
-            let rec = htslib::sam_hdr_parse(
-                (l_text + 1) as i32,
-                text as *const i8,
-            );
+            let rec = htslib::sam_hdr_parse((l_text + 1) as i32, text as *const i8);
             (*rec).text = text as *mut i8;
             (*rec).l_text = l_text as u32;
             rec
@@ -1014,7 +1008,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         assert!(names[0] != names[1]);
 
-        for i in 0 .. names.len() {
+        for i in 0..names.len() {
             let mut rec = record::Record::new();
             rec.set(names[i], &cigars[i], seqs[i], quals[i]);
             rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
@@ -1065,9 +1059,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_set_qname2() {
-
         let mut _header = Header::new();
-        _header.push_record(HeaderRecord::new(b"SQ").push_tag(b"SN", &"1").push_tag(b"LN", &10000000));
+        _header.push_record(
+            HeaderRecord::new(b"SQ")
+                .push_tag(b"SN", &"1")
+                .push_tag(b"LN", &10000000),
+        );
         let header = HeaderView::from_header(&_header);
 
         let line = b"blah1	0	1	1	255	1M	*	0	0	A	F	CB:Z:AAAA-1	UR:Z:AAAA	UB:Z:AAAA	GX:Z:G1	xf:i:1	fx:Z:G1\tli:i:0\ttf:Z:cC";

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -390,38 +390,47 @@ impl Record {
         }
     }
 
-    /// Return unpacked cigar string. This returns None unless you have first called
-    /// `bam::Record::UnpackCigar`.
-    pub fn cigar(&self) -> Option<&CigarStringView> {
+    /// Return unpacked cigar string. This will create a fresh copy the Cigar data.
+    pub fn cigar(&self) -> CigarStringView {
+        match self.cigar {
+            Some(ref c) => c.clone(),
+            None => self.unpack_cigar()
+        }
+    }
+
+    // Return unpacked cigar string. This returns None unless you have first called `bam::Record::cache_cigar`.
+    pub fn cigar_cached(&self) -> Option<&CigarStringView> 
+    {
         self.cigar.as_ref()
     }
 
+
+    /// Decode the cigar string and cache it inside the `Record`
+    pub fn cache_cigar(&mut self) {
+        self.cigar = Some(self.unpack_cigar())
+    }
+
     /// Unpack cigar string. Complexity: O(k) with k being the length of the cigar string.
-    pub fn unpack_cigar(&mut self) {
-        self.cigar = {
-            let raw = self.raw_cigar();
-            Some(
-                CigarString(
-                    raw.iter()
-                        .map(|&c| {
-                            let len = c >> 4;
-                            match c & 0b1111 {
-                                0 => Cigar::Match(len),
-                                1 => Cigar::Ins(len),
-                                2 => Cigar::Del(len),
-                                3 => Cigar::RefSkip(len),
-                                4 => Cigar::SoftClip(len),
-                                5 => Cigar::HardClip(len),
-                                6 => Cigar::Pad(len),
-                                7 => Cigar::Equal(len),
-                                8 => Cigar::Diff(len),
-                                _ => panic!("Unexpected cigar operation"),
-                            }
-                        })
-                        .collect(),
-                ).into_view(self.pos()),
-            )
-        };
+    fn unpack_cigar(&self) -> CigarStringView {
+        CigarString(
+            self.raw_cigar().iter()
+                .map(|&c| {
+                    let len = c >> 4;
+                    match c & 0b1111 {
+                        0 => Cigar::Match(len),
+                        1 => Cigar::Ins(len),
+                        2 => Cigar::Del(len),
+                        3 => Cigar::RefSkip(len),
+                        4 => Cigar::SoftClip(len),
+                        5 => Cigar::HardClip(len),
+                        6 => Cigar::Pad(len),
+                        7 => Cigar::Equal(len),
+                        8 => Cigar::Diff(len),
+                        _ => panic!("Unexpected cigar operation"),
+                    }
+                })
+                .collect(),
+        ).into_view(self.pos())
     }
 
     fn seq_len(&self) -> usize {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -70,10 +70,15 @@ impl Clone for Record {
 
 impl PartialEq for Record {
     fn eq(&self, other: &Record) -> bool {
-        self.tid() == other.tid() && self.pos() == other.pos() && self.bin() == other.bin()
-            && self.mapq() == other.mapq() && self.flags() == other.flags()
-            && self.mtid() == other.mtid() && self.mpos() == other.mpos()
-            && self.insert_size() == other.insert_size() && self.data() == other.data()
+        self.tid() == other.tid()
+            && self.pos() == other.pos()
+            && self.bin() == other.bin()
+            && self.mapq() == other.mapq()
+            && self.flags() == other.flags()
+            && self.mtid() == other.mtid()
+            && self.mpos() == other.mpos()
+            && self.insert_size() == other.insert_size()
+            && self.data() == other.data()
     }
 }
 
@@ -266,7 +271,9 @@ impl Record {
     pub fn set(&mut self, qname: &[u8], cigar: &CigarString, seq: &[u8], qual: &[u8]) {
         self.cigar = None;
 
-        self.inner_mut().l_data = (qname.len() + 1 + cigar.len() * 4
+        self.inner_mut().l_data = (qname.len()
+            + 1
+            + cigar.len() * 4
             + ((seq.len() as f32 / 2.0).ceil() as usize)
             + qual.len()) as i32;
 
@@ -394,16 +401,14 @@ impl Record {
     pub fn cigar(&self) -> CigarStringView {
         match self.cigar {
             Some(ref c) => c.clone(),
-            None => self.unpack_cigar()
+            None => self.unpack_cigar(),
         }
     }
 
     // Return unpacked cigar string. This returns None unless you have first called `bam::Record::cache_cigar`.
-    pub fn cigar_cached(&self) -> Option<&CigarStringView> 
-    {
+    pub fn cigar_cached(&self) -> Option<&CigarStringView> {
         self.cigar.as_ref()
     }
-
 
     /// Decode the cigar string and cache it inside the `Record`
     pub fn cache_cigar(&mut self) {
@@ -413,7 +418,8 @@ impl Record {
     /// Unpack cigar string. Complexity: O(k) with k being the length of the cigar string.
     fn unpack_cigar(&self) -> CigarStringView {
         CigarString(
-            self.raw_cigar().iter()
+            self.raw_cigar()
+                .iter()
                 .map(|&c| {
                     let len = c >> 4;
                     match c & 0b1111 {

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -259,7 +259,8 @@ impl Read for IndexedReader {
 
                 match self.current_region {
                     Some((rid, _start, end)) => {
-                        if record.rid().is_some() && rid == record.rid().unwrap()
+                        if record.rid().is_some()
+                            && rid == record.rid().unwrap()
                             && record.pos() <= end
                         {
                             Ok(())


### PR DESCRIPTION
also includes a rustfmt (some rules seem to have changed?)