### PR TITLE
feat: add musl target support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
       - kalakris-cmake
 
 before_script:
-  - cargo install --force cargo-travis
+  - cargo install cargo-travis || true
   - export PATH=$HOME/.cargo/bin:$PATH
   - rustup component add rustfmt-preview
   - rustup target add x86_64-unknown-linux-musl

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ addons:
       - libdw-dev
       - binutils-dev
       - cmake
+      - musl
+      - musl-dev
+      - musl-tools
     sources:
       - kalakris-cmake
 
@@ -23,12 +26,19 @@ before_script:
   - cargo install --force cargo-travis
   - export PATH=$HOME/.cargo/bin:$PATH
   - rustup component add rustfmt-preview
+  - rustup target add x86_64-unknown-linux-musl
 
 script:
   - cargo fmt --version
   - cargo fmt -- --check
   - cargo build
   - cargo test
+  - cargo build --no-default-features
+  - cargo test --no-default-features
+  - cargo build --target x86_64-unknown-linux-musl
+  - cargo test --target x86_64-unknown-linux-musl
+  - cargo build --target x86_64-unknown-linux-musl --no-default-features
+  - cargo test --target x86_64-unknown-linux-musl --no-default-features
 
 after_success:
   - cargo coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
       - libelf-dev
       - libdw-dev
       - binutils-dev
+      - libiberty-dev
       - cmake
       - musl
       - musl-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ documentation = "https://docs.rs/rust-htslib"
 
 [dependencies]
 libc = "0.2"
+libz-sys ="1.0"
+bzip2-sys = { version = "0.1.6", git = "https://github.com/alexcrichton/bzip2-rs.git", optional = true }
+lzma-sys = { version = "0.1.10", optional = true }
 itertools = "0.6"
 quick-error = "1.2"
 newtype_derive = "0.1"
@@ -28,8 +31,8 @@ bio-types = ">=0.1.1"
 
 [features]
 default = ["bzip2", "lzma"]
-bzip2 = []
-lzma = []
+bzip2 = ["bzip2-sys"]
+lzma = ["lzma-sys"]
 
 [dev-dependencies]
 tempdir = "0.3"
@@ -40,3 +43,4 @@ pretty_assertions = "0.5.1"
 [build-dependencies]
 fs-utils = "1.0"
 bindgen = "0.36"
+cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/rust-htslib"
 
 [dependencies]
 libc = "0.2"
-libz-sys ="1.0"
+libz-sys = "1.0"
 bzip2-sys = { version = "0.1.6", git = "https://github.com/alexcrichton/bzip2-rs.git", optional = true }
 lzma-sys = { version = "0.1.10", optional = true }
 itertools = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn sed_htslib_makefile(out: &PathBuf, patterns: &Vec<&str>, feature: &str) {
 fn main() {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
     let mut cfg = cc::Build::new();
-    cfg.warnings(false).static_flag(true);
+    cfg.warnings(false).static_flag(true).pic(true);
 
     if let Ok(z_inc) = env::var("DEP_Z_INCLUDE") {
         cfg.include(z_inc);
@@ -102,11 +102,4 @@ fn main() {
     println!("cargo:include={}", include.display());
     println!("cargo:libdir={}", out.display());
     println!("cargo:rustc-link-lib=static=hts");
-    println!("cargo:rustc-link-lib=static=z");
-    if use_bzip2 {
-        println!("cargo:rustc-link-lib=static=bz2");
-    }
-    if use_lzma {
-        println!("cargo:rustc-link-lib=static=lzma");
-    }
 }

--- a/build.rs
+++ b/build.rs
@@ -4,11 +4,13 @@
 // except according to those terms.
 
 extern crate bindgen;
+extern crate cc;
 extern crate fs_utils;
 
 use fs_utils::copy::copy_directory;
 
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -31,6 +33,13 @@ fn sed_htslib_makefile(out: &PathBuf, patterns: &Vec<&str>, feature: &str) {
 
 fn main() {
     let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let mut cfg = cc::Build::new();
+    cfg.warnings(false).static_flag(true);
+
+    if let Ok(z_inc) = env::var("DEP_Z_INCLUDE") {
+        cfg.include(z_inc);
+    }
+
     if !out.join("htslib").exists() {
         copy_directory("htslib", &out).unwrap();
     }
@@ -39,17 +48,28 @@ fn main() {
     if !use_bzip2 {
         let bzip2_patterns = vec!["s/ -lbz2//", "/#define HAVE_LIBBZ2/d"];
         sed_htslib_makefile(&out, &bzip2_patterns, "bzip2");
+    } else if let Ok(inc) = env::var("DEP_BZIP2_ROOT")
+        .map(PathBuf::from)
+        .map(|path| path.join("include"))
+    {
+        cfg.include(inc);
     }
 
     let use_lzma = env::var("CARGO_FEATURE_LZMA").is_ok();
     if !use_lzma {
         let lzma_patterns = vec!["s/ -llzma//", "/#define HAVE_LIBLZMA/d"];
         sed_htslib_makefile(&out, &lzma_patterns, "lzma");
+    } else if let Ok(inc) = env::var("DEP_LZMA_INCLUDE").map(PathBuf::from) {
+        cfg.include(inc);
     }
 
+    let tool = cfg.get_compiler();
+    let (cc_path, cflags_env) = (tool.path(), tool.cflags_env());
+    let cc_cflags = cflags_env.to_string_lossy().replace("-O0", "");
     if Command::new("make")
         .current_dir(out.join("htslib"))
-        .arg("CFLAGS=-g -Wall -O2 -fPIC")
+        .arg(format!("CC={}", cc_path.display()))
+        .arg(format!("CFLAGS={}", cc_cflags))
         .arg("lib-static")
         .arg("-B")
         .status()
@@ -59,47 +79,34 @@ fn main() {
         panic!("failed to build htslib");
     }
 
-    let bindings = bindgen::Builder::default()
+    cfg.file("wrapper.c").compile("wrapper");
+
+    bindgen::Builder::default()
         .header("wrapper.h")
         .generate_comments(false)
         .blacklist_type("max_align_t")
         .generate()
-        .expect("Unable to generate bindings.");
-    bindings
+        .expect("Unable to generate bindings.")
         .write_to_file(out.join("bindings.rs"))
         .expect("Could not write bindings.");
 
-    // we additionally build and link to the wrapper in order to enable redefinition of inline
-    // functions
-    if Command::new("gcc")
-        .arg("-static")
-        .arg("-fPIC")
-        .arg("-c")
-        .arg("wrapper.c")
-        .arg("-o")
-        .arg(out.join("wrapper.o"))
-        .status()
-        .unwrap()
-        .success() != true
-    {
-        panic!("failed to build wrapper.o");
+    let include = out.join("include");
+    fs::create_dir_all(&include).unwrap();
+    if include.join("htslib").exists() {
+        fs::remove_dir_all(include.join("htslib")).expect("remove exist include dir");
     }
-    if Command::new("ar")
-        .current_dir(&out)
-        .arg("rcs")
-        .arg("libwrapper.a")
-        .arg("wrapper.o")
-        .status()
-        .unwrap()
-        .success() != true
-    {
-        panic!("failed to build wrapper.a");
-    }
+    copy_directory(out.join("htslib").join("htslib"), &include).unwrap();
+    fs::copy(out.join("htslib").join("libhts.a"), out.join("libhts.a")).unwrap();
 
-    println!(
-        "cargo:rustc-flags=-L {out}/htslib -L {out} -l static=hts -l static=wrapper -l z {lzma} {bzip2}",
-        out = out.to_str().unwrap(),
-        lzma = if use_lzma { "-l lzma" } else { "" },
-        bzip2 = if use_bzip2 { "-l bz2" } else { "" },
-    );
+    println!("cargo:root={}", out.display());
+    println!("cargo:include={}", include.display());
+    println!("cargo:libdir={}", out.display());
+    println!("cargo:rustc-link-lib=static=hts");
+    println!("cargo:rustc-link-lib=static=z");
+    if use_bzip2 {
+        println!("cargo:rustc-link-lib=static=bz2");
+    }
+    if use_lzma {
+        println!("cargo:rustc-link-lib=static=lzma");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ extern crate pretty_assertions;
 extern crate serde_json;
 
 extern crate bio_types;
+#[cfg(feature = "bzip2")]
+extern crate bzip2_sys;
 
 pub mod bam;
 pub mod bcf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,13 @@ extern crate pretty_assertions;
 extern crate serde_json;
 
 extern crate bio_types;
+
+extern crate libz_sys;
+
 #[cfg(feature = "bzip2")]
 extern crate bzip2_sys;
+#[cfg(feature = "lzma")]
+extern crate lzma_sys;
 
 pub mod bam;
 pub mod bcf;


### PR DESCRIPTION
Changes:
- explicitly declare deps for `bzip2` and `lzma` feature.
- add musl target support using `cc` crate.

Though I choose to link native deps via the `bzip2-sys` and `lzma-sys` crates,
note that the deps could be done with cargo's `target` selector.
Let me know if you do not want to link it by default.

/cc #80