### PR TITLE
increase version range of bindgen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - libcurl4-openssl-dev
       - libelf-dev
       - libdw-dev
+      - libbz2-dev
       - binutils-dev
       - libiberty-dev
       - cmake

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,5 @@ pretty_assertions = "0.5.1"
 
 [build-dependencies]
 fs-utils = "1.0"
-bindgen = "0.36"
+bindgen = ">=0.37"
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/rust-htslib"
 [dependencies]
 libc = "0.2"
 libz-sys = "1.0"
-bzip2-sys = { version = "0.1.5", optional = true }
+bzip2-sys = { version = "0.1.7", optional = true }
 lzma-sys = { version = "0.1.10", optional = true }
 itertools = "0.6"
 quick-error = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ documentation = "https://docs.rs/rust-htslib"
 [dependencies]
 libc = "0.2"
 libz-sys = "1.0"
-bzip2-sys = { version = "0.1.6", optional = true }
+bzip2-sys = { version = "0.1.5", optional = true }
 lzma-sys = { version = "0.1.10", optional = true }
 itertools = "0.6"
 quick-error = "1.2"

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,8 @@ fn sed_htslib_makefile(out: &PathBuf, patterns: &Vec<&str>, feature: &str) {
             .arg("Makefile")
             .status()
             .unwrap()
-            .success() != true
+            .success()
+            != true
         {
             panic!("failed to strip {} support", feature);
         }
@@ -74,7 +75,8 @@ fn main() {
         .arg("-B")
         .status()
         .unwrap()
-        .success() != true
+        .success()
+        != true
     {
         panic!("failed to build htslib");
     }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1116,8 +1116,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-            )
-            .ok()
+            ).ok()
             .expect("Error opening file.");
 
             for i in 0..names.len() {
@@ -1166,8 +1165,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-            )
-            .ok()
+            ).ok()
             .expect("Error opening file.");
             bam.set_threads(4).unwrap();
 

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1116,8 +1116,9 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-            ).ok()
-                .expect("Error opening file.");
+            )
+            .ok()
+            .expect("Error opening file.");
 
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
@@ -1165,8 +1166,9 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-            ).ok()
-                .expect("Error opening file.");
+            )
+            .ok()
+            .expect("Error opening file.");
             bam.set_threads(4).unwrap();
 
             for i in 0..10000 {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -309,11 +309,12 @@ impl Record {
         // seq
         {
             for j in (0..seq.len()).step(2) {
-                data[i + j / 2] = ENCODE_BASE[seq[j] as usize] << 4 | (if j + 1 < seq.len() {
-                    ENCODE_BASE[seq[j + 1] as usize]
-                } else {
-                    0
-                });
+                data[i + j / 2] = ENCODE_BASE[seq[j] as usize] << 4
+                    | (if j + 1 < seq.len() {
+                        ENCODE_BASE[seq[j + 1] as usize]
+                    } else {
+                        0
+                    });
             }
             self.inner_mut().core.l_qseq = seq.len() as i32;
             i += (seq.len() + 1) / 2;
@@ -438,7 +439,8 @@ impl Record {
                     }
                 })
                 .collect(),
-        ).into_view(self.pos())
+        )
+        .into_view(self.pos())
     }
 
     fn seq_len(&self) -> usize {
@@ -1202,7 +1204,8 @@ mod tests {
             Cigar::Del(2),
             Cigar::Diff(1),
             Cigar::Equal(2),
-        ]).into_view(0);
+        ])
+        .into_view(0);
         assert_eq!(c05.read_pos(vpos, true, false).unwrap(), Some(3));
 
         // single nucleotide Deletion covering variant position
@@ -1233,7 +1236,8 @@ mod tests {
             Cigar::Diff(1),
             Cigar::RefSkip(3),
             Cigar::Match(2),
-        ]).into_view(2);
+        ])
+        .into_view(2);
         assert_eq!(c08.read_pos(vpos, false, true).unwrap(), None);
         assert_eq!(c08.read_pos(vpos, false, false).unwrap(), None);
 
@@ -1247,7 +1251,8 @@ mod tests {
             Cigar::Equal(2),
             Cigar::HardClip(3),
             Cigar::Equal(2),
-        ]).into_view(2);
+        ])
+        .into_view(2);
         assert_eq!(c09.read_pos(vpos, false, true).is_err(), true);
 
         // Deletion right before variant position
@@ -1305,7 +1310,8 @@ mod tests {
             Cigar::Equal(2),
             Cigar::SoftClip(5),
             Cigar::HardClip(2),
-        ]).into_view(0);
+        ])
+        .into_view(0);
         assert_eq!(c14.read_pos(vpos2, false, false).unwrap(), Some(19));
 
         // HardClip after Pad

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -437,10 +437,8 @@ impl Record {
                         8 => Cigar::Diff(len),
                         _ => panic!("Unexpected cigar operation"),
                     }
-                })
-                .collect(),
-        )
-        .into_view(self.pos())
+                }).collect(),
+        ).into_view(self.pos())
     }
 
     fn seq_len(&self) -> usize {
@@ -1204,8 +1202,7 @@ mod tests {
             Cigar::Del(2),
             Cigar::Diff(1),
             Cigar::Equal(2),
-        ])
-        .into_view(0);
+        ]).into_view(0);
         assert_eq!(c05.read_pos(vpos, true, false).unwrap(), Some(3));
 
         // single nucleotide Deletion covering variant position
@@ -1236,8 +1233,7 @@ mod tests {
             Cigar::Diff(1),
             Cigar::RefSkip(3),
             Cigar::Match(2),
-        ])
-        .into_view(2);
+        ]).into_view(2);
         assert_eq!(c08.read_pos(vpos, false, true).unwrap(), None);
         assert_eq!(c08.read_pos(vpos, false, false).unwrap(), None);
 
@@ -1251,8 +1247,7 @@ mod tests {
             Cigar::Equal(2),
             Cigar::HardClip(3),
             Cigar::Equal(2),
-        ])
-        .into_view(2);
+        ]).into_view(2);
         assert_eq!(c09.read_pos(vpos, false, true).is_err(), true);
 
         // Deletion right before variant position
@@ -1310,8 +1305,7 @@ mod tests {
             Cigar::Equal(2),
             Cigar::SoftClip(5),
             Cigar::HardClip(2),
-        ])
-        .into_view(0);
+        ]).into_view(0);
         assert_eq!(c14.read_pos(vpos2, false, false).unwrap(), Some(19));
 
         // HardClip after Pad

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -49,7 +49,6 @@ impl<'de> Deserialize<'de> for Record {
             Data,
         };
 
-
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
             where

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -80,7 +80,7 @@ impl Header {
             htslib::bcf_hdr_subset(
                 header.inner,
                 samples.len() as i32,
-                name_pointers.as_ptr() as *const *const i8,
+                name_pointers.as_ptr() as *const *mut i8,
                 imap.as_mut_ptr() as *mut i32,
             )
         };

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1013,13 +1013,15 @@ mod tests {
                     .expect("Error reading integer.")[1],
                 fn4[i]
             );
-            assert!(record
-                .format(b"FF4")
-                .float()
-                .ok()
-                .expect("Error reading float.")[1]
-                .iter()
-                .all(|&v| v.is_missing()));
+            assert!(
+                record
+                    .format(b"FF4")
+                    .float()
+                    .ok()
+                    .expect("Error reading float.")[1]
+                    .iter()
+                    .all(|&v| v.is_missing())
+            );
         }
     }
 

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1013,15 +1013,13 @@ mod tests {
                     .expect("Error reading integer.")[1],
                 fn4[i]
             );
-            assert!(
-                record
-                    .format(b"FF4")
-                    .float()
-                    .ok()
-                    .expect("Error reading float.")[1]
-                    .iter()
-                    .all(|&v| v.is_missing())
-            );
+            assert!(record
+                .format(b"FF4")
+                .float()
+                .ok()
+                .expect("Error reading float.")[1]
+                .iter()
+                .all(|&v| v.is_missing()));
         }
     }
 

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -777,8 +777,7 @@ impl<'a> Info<'a> {
                         s.split(|c| *c == 0u8)
                             .next()
                             .expect("Bug: returned string should not be empty.")
-                    })
-                    .collect()
+                    }).collect()
             })
         })
     }
@@ -880,8 +879,7 @@ impl<'a> Format<'a> {
                     s.split(|c| *c == 0u8)
                         .next()
                         .expect("Bug: returned string should not be empty.")
-                })
-                .collect()
+                }).collect()
         })
     }
 }

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -134,9 +134,11 @@ mod tests {
                 match f(&parsed) {
                     None => return true,
                     Some(false) => {}
-                    Some(true) => if let Err(_) = sam_writer.write(&parsed) {
-                        return false;
-                    },
+                    Some(true) => {
+                        if let Err(_) = sam_writer.write(&parsed) {
+                            return false;
+                        }
+                    }
                 }
             }
             true
@@ -150,18 +152,14 @@ mod tests {
         assert!(result);
         let mut expected = Vec::new();
         let mut written = Vec::new();
-        assert!(
-            File::open(expectedfile)
-                .unwrap()
-                .read_to_end(&mut expected)
-                .is_ok()
-        );
-        assert!(
-            File::open(samfile)
-                .unwrap()
-                .read_to_end(&mut written)
-                .is_ok()
-        );
+        assert!(File::open(expectedfile)
+            .unwrap()
+            .read_to_end(&mut expected)
+            .is_ok());
+        assert!(File::open(samfile)
+            .unwrap()
+            .read_to_end(&mut written)
+            .is_ok());
         assert_eq!(expected, written);
     }
 }

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -152,14 +152,18 @@ mod tests {
         assert!(result);
         let mut expected = Vec::new();
         let mut written = Vec::new();
-        assert!(File::open(expectedfile)
-            .unwrap()
-            .read_to_end(&mut expected)
-            .is_ok());
-        assert!(File::open(samfile)
-            .unwrap()
-            .read_to_end(&mut written)
-            .is_ok());
+        assert!(
+            File::open(expectedfile)
+                .unwrap()
+                .read_to_end(&mut expected)
+                .is_ok()
+        );
+        assert!(
+            File::open(samfile)
+                .unwrap()
+                .read_to_end(&mut written)
+                .is_ok()
+        );
         assert_eq!(expected, written);
     }
 }


### PR DESCRIPTION
Allow a wider range of bindgen versions. Bindgen depends on clang-sys which has a native dependency, therefore only one version can be present in a build.  Pinning to a single bindgen version makes it difficult to combine rust-htslib with other crates that use bindgen. 

I've tested that bindgen 0.37 - 0.43 pass the rust-htslib tests.