### PR TITLE
bam: fix l_extranul processing when deserializing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ before_script:
 script:
   - cargo fmt --version
   - cargo fmt -- --check
-  - cargo build
-  - cargo test
+  - cargo build --all-features
+  - cargo test --all-features
   - cargo build --no-default-features
   - cargo test --no-default-features
-  - cargo build --target x86_64-unknown-linux-musl
-  - cargo test --target x86_64-unknown-linux-musl
+  - cargo build --target x86_64-unknown-linux-musl --all-features
+  - cargo test --target x86_64-unknown-linux-musl --all-features
   - cargo build --target x86_64-unknown-linux-musl --no-default-features
   - cargo test --target x86_64-unknown-linux-musl --no-default-features
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -240,14 +240,18 @@ impl Record {
         self.inner_mut().core.isize = insert_size;
     }
 
-    fn qname_len(&self) -> usize {
+    fn qname_capacity(&self) -> usize {
         self.inner().core.l_qname as usize
+    }
+
+    fn qname_len(&self) -> usize {
+        // discount all trailing zeros (the default one and extra nulls)
+        self.qname_capacity() - 1 - self.inner().core.l_extranul as usize
     }
 
     /// Get qname (read name). Complexity: O(1).
     pub fn qname(&self) -> &[u8] {
-        // remove all trailing zeros (the default one and extra nulls)
-        &self.data()[..self.qname_len() - 1 - self.inner().core.l_extranul as usize]
+        &self.data()[..self.qname_len()]
     }
 
     /// Set the variable length data buffer
@@ -331,7 +335,7 @@ impl Record {
     pub fn set_qname(&mut self, new_qname: &[u8]) {
         assert!(new_qname.len() <= 256);
 
-        let old_q_len = self.qname_len();
+        let old_q_len = self.qname_capacity();
         // We're going to add a terminal NUL
         let new_q_len = 1 + new_qname.len();
 
@@ -395,7 +399,7 @@ impl Record {
     pub fn raw_cigar(&self) -> &[u32] {
         unsafe {
             slice::from_raw_parts(
-                self.data()[self.qname_len()..].as_ptr() as *const u32,
+                self.data()[self.qname_capacity()..].as_ptr() as *const u32,
                 self.cigar_len(),
             )
         }
@@ -449,7 +453,7 @@ impl Record {
     /// Get read sequence. Complexity: O(1).
     pub fn seq(&self) -> Seq {
         Seq {
-            encoded: &self.data()[self.qname_len() + self.cigar_len() * 4..]
+            encoded: &self.data()[self.qname_capacity() + self.cigar_len() * 4..]
                 [..(self.seq_len() + 1) / 2],
             len: self.seq_len(),
         }
@@ -459,7 +463,7 @@ impl Record {
     /// This does not entail any offsets, hence the qualities can be used directly without
     /// e.g. subtracting 33. Complexity: O(1).
     pub fn qual(&self) -> &[u8] {
-        &self.data()[self.qname_len() + self.cigar_len() * 4 + (self.seq_len() + 1) / 2..]
+        &self.data()[self.qname_capacity() + self.cigar_len() * 4 + (self.seq_len() + 1) / 2..]
             [..self.seq_len()]
     }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -81,6 +81,7 @@ impl PartialEq for Record {
             && self.mpos() == other.mpos()
             && self.insert_size() == other.insert_size()
             && self.data() == other.data()
+            && self.inner().core.l_extranul == other.inner().core.l_extranul
     }
 }
 

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -6,6 +6,12 @@ use serde::{Serialize, Serializer};
 
 use bam::record::Record;
 
+fn fix_l_extranul(mut rec: Record) -> Record {
+    let l_extranul = rec.qname().iter().rev().take_while(|x| **x == 0u8).count() as u8;
+    rec.inner_mut().core.l_extranul = l_extranul;
+    rec
+}
+
 impl Serialize for Record {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -156,9 +162,8 @@ impl<'de> Deserialize<'de> for Record {
                     m.isize = isize;
                 }
 
-                //println!()
                 rec.set_data(&data);
-                Ok(rec)
+                Ok(fix_l_extranul(rec))
             }
 
             fn visit_map<V>(self, mut map: V) -> Result<Record, V::Error>
@@ -286,7 +291,7 @@ impl<'de> Deserialize<'de> for Record {
                 }
 
                 rec.set_data(&data);
-                Ok(rec)
+                Ok(fix_l_extranul(rec))
             }
         }
 


### PR DESCRIPTION
Turns out if you don't do this, you may see between 1-3 extra null bytes at the end of your record qname because of alignment padding.