### PR TITLE
Fix `rid2name` out-of-bound errors in bcf module

### DIFF
--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -240,6 +240,7 @@ impl HeaderView {
         unsafe { (*self.inner) }
     }
 
+    /// Get the number of samples defined in the header.
     pub fn sample_count(&self) -> u32 {
         self.inner().n[htslib::BCF_DT_SAMPLE as usize] as u32
     }
@@ -260,11 +261,20 @@ impl HeaderView {
         self.samples().iter().position(|s| *s == sample)
     }
 
-    pub fn rid2name(&self, rid: u32) -> &[u8] {
-        unsafe {
-            let dict = self.inner().id[htslib::BCF_DT_CTG as usize];
-            let ptr = (*dict.offset(rid as isize)).key;
-            ffi::CStr::from_ptr(ptr).to_bytes()
+    /// Get the number of contigs defined in the header.
+    pub fn contig_count(&self) -> u32 {
+        self.inner().n[htslib::BCF_DT_CTG as usize] as u32
+    }
+
+    pub fn rid2name(&self, rid: u32) -> Result<&[u8], RidError> {
+        if rid <= self.contig_count() {
+            unsafe {
+                let dict = self.inner().id[htslib::BCF_DT_CTG as usize];
+                let ptr = (*dict.offset(rid as isize)).key;
+                Ok(ffi::CStr::from_ptr(ptr).to_bytes())
+            }
+        } else {
+            Err(RidError::UnknownRID(rid))
         }
     }
 
@@ -480,6 +490,10 @@ quick_error! {
         UnknownSequence(name: String) {
             description("unknown sequence")
             display("sequence {} not found in header", name)
+        }
+        UnknownRID(rid: u32) {
+            description("unknown RID")
+            display("RID {} not found in header", rid)
         }
     }
 }

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -266,7 +266,7 @@ impl HeaderView {
         self.inner().n[htslib::BCF_DT_CTG as usize] as u32
     }
 
-    pub fn rid2name(&self, rid: u32) -> Result<&[u8], RidError> {
+    pub fn rid2name(&self, rid: u32) -> Result<&[u8], RidIndexError> {
         if rid <= self.contig_count() {
             unsafe {
                 let dict = self.inner().id[htslib::BCF_DT_CTG as usize];
@@ -274,7 +274,7 @@ impl HeaderView {
                 Ok(ffi::CStr::from_ptr(ptr).to_bytes())
             }
         } else {
-            Err(RidError::UnknownRID(rid))
+            Err(RidIndexError::UnknownIndex(rid))
         }
     }
 
@@ -491,9 +491,15 @@ quick_error! {
             description("unknown sequence")
             display("sequence {} not found in header", name)
         }
-        UnknownRID(rid: u32) {
-            description("unknown RID")
-            display("RID {} not found in header", rid)
+    }
+}
+
+quick_error! {
+    #[derive(Debug, Clone)]
+    pub enum RidIndexError {
+        UnknownIndex(rid: u32) {
+            description("unknown index")
+            display("index {} not found in header", rid)
         }
     }
 }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1072,6 +1072,24 @@ mod tests {
     }
 
     #[test]
+    fn test_header_contigs() {
+        let vcf = Reader::from_path(&"test/test_multi.bcf")
+            .ok()
+            .expect("Error opening file.");
+        let header = &vcf.header();
+
+        assert_eq!(header.rid2name(0), b"1");
+        assert_eq!(header.name2rid(b"1").unwrap(), 0);
+
+        assert_eq!(header.rid2name(85), b"hs37d5");
+        assert_eq!(header.name2rid(b"hs37d5").unwrap(), 85);
+
+        // test nonexistent contig names and IDs
+        assert!(header.name2rid(b"nonexistent_contig").is_err());
+        header.rid2name(100); // segfault
+    }
+
+    #[test]
     fn test_header_records() {
         let vcf = Reader::from_path(&"test/test_string.vcf")
             .ok()

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -220,7 +220,7 @@ impl IndexedReader {
     /// * `start` - `0`-based start coordinate of region on reference.
     /// * `end` - `0`-based end coordinate of region on reference.
     pub fn fetch(&mut self, rid: u32, start: u32, end: u32) -> Result<(), FetchError> {
-        let contig = self.header.rid2name(rid);
+        let contig = self.header.rid2name(rid).unwrap();
         let contig = ffi::CString::new(contig).unwrap();
         let contig = contig.as_ptr();
         if unsafe { htslib::bcf_sr_seek(self.inner, contig, start as i32) } != 0 {
@@ -495,7 +495,7 @@ pub mod synced {
         /// * `end` - `0`-based end coordinate of region on reference.
         pub fn fetch(&mut self, rid: u32, start: u32, end: u32) -> Result<(), FetchError> {
             let contig = {
-                let contig = self.header(0).rid2name(rid).clone();
+                let contig = self.header(0).rid2name(rid).unwrap().clone();
                 ffi::CString::new(contig).unwrap()
             };
             let contig = contig.as_ptr();
@@ -1078,15 +1078,18 @@ mod tests {
             .expect("Error opening file.");
         let header = &vcf.header();
 
-        assert_eq!(header.rid2name(0), b"1");
+        assert_eq!(header.contig_count(), 86);
+
+        // test existing contig names and IDs
+        assert_eq!(header.rid2name(0).unwrap(), b"1");
         assert_eq!(header.name2rid(b"1").unwrap(), 0);
 
-        assert_eq!(header.rid2name(85), b"hs37d5");
+        assert_eq!(header.rid2name(85).unwrap(), b"hs37d5");
         assert_eq!(header.name2rid(b"hs37d5").unwrap(), 85);
 
         // test nonexistent contig names and IDs
         assert!(header.name2rid(b"nonexistent_contig").is_err());
-        header.rid2name(100); // segfault
+        assert!(header.rid2name(100).is_err());
     }
 
     #[test]


### PR DESCRIPTION
`bcf::header::rid2name(rid)` leads to segfaults if `rid` is larger than the number of contigs defined in the VCF header (`htslib::BCF_DT_CTG`). This is caused by an out-of-bound array access within an unsafe block.

The core part of the fix checks if the requested `rid` is within the range of defined contigs, and returns an error otherwise. This required changing `rid2name` to return an `Result<u32, RidIndexError>` since the previous return type (`u32`) didn't allow signalling the failure case. Please note that is a breaking change.

Summary of changes:
- Checks for valid `rid` in `rid2name`: This prevents the segfaults due to the out-of-bound access.
- Changes the return type of `rid2name` from `u32` to `Result<u32, RidIndexError>`, analogous to its counterpart `name2rid`. This is a breaking change!
- Introduces a new error variant `RidIndexError:: UnknownIndex(u32)`, analogous to the existing `RidError: UnknownSequence`.
- Adds a new public `contig_count` method which returns the number of defined contigs, similar to `sample_count`. This can be handy for checking the number of contigs or iterating over all contig names together with `rid2name`.
- Adds test cases for valid and invalid queries for `rid2name` and `name2rid`.