### PR TITLE
Added option for setting unmapped BAM record

### DIFF
--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -9145,7 +9145,7 @@ mod tests {
         ] {
             read.set(
                 b"test",
-                &CigarString::from_str(input_cigar).unwrap(),
+                Some(&CigarString::from_str(input_cigar).unwrap()),
                 b"agtc",
                 b"BBBB",
             );

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1151,7 +1151,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         let mut rec = record::Record::new();
         rec.set_reverse();
-        rec.set(names[0], &cigars[0], seqs[0], quals[0]);
+        rec.set(names[0], Some(&cigars[0]), seqs[0], quals[0]);
         // note: this segfaults if you push_aux() before set()
         //       because set() obliterates aux
         rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
@@ -1172,7 +1172,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         for i in 0..names.len() {
             let mut rec = record::Record::new();
-            rec.set(names[i], &cigars[i], seqs[i], quals[i]);
+            rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
             rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
 
             assert_eq!(rec.qname(), names[i]);
@@ -1285,7 +1285,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
-                rec.set(names[i], &cigars[i], seqs[i], quals[i]);
+                rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
                 rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
 
                 bam.write(&mut rec).ok().expect("Failed to write record.");
@@ -1337,7 +1337,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             for i in 0..10000 {
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
-                rec.set(names[idx], &cigars[idx], seqs[idx], quals[idx]);
+                rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
                 rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
                 rec.set_pos(i as i32);
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -278,13 +278,15 @@ impl Record {
     pub fn set(&mut self, qname: &[u8], cigar: Option<&CigarString>, seq: &[u8], qual: &[u8]) {
         self.cigar = None;
 
+        let cigar_width = if let Some(cigar_string) = cigar {
+            cigar_string.len()
+        } else {
+            0
+        } * 4;
+
         self.inner_mut().l_data = (qname.len()
             + 1
-            + if let Some(cigar_string) = cigar {
-                cigar_string.len()
-            } else {
-                0
-            } * 4
+            + cigar_width
             + ((seq.len() as f32 / 2.0).ceil() as usize)
             + qual.len()) as i32;
 
@@ -316,7 +318,7 @@ impl Record {
             i += cigar_string.len() * 4;
         } else {
             self.inner_mut().core.n_cigar = 0;
-        }
+        };
 
         // seq
         {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -275,12 +275,16 @@ impl Record {
     /// Note: Pre-existing aux data will be invalidated
     /// if called on an existing record. For this
     /// reason, never call push_aux() before set().
-    pub fn set(&mut self, qname: &[u8], cigar: &CigarString, seq: &[u8], qual: &[u8]) {
+    pub fn set(&mut self, qname: &[u8], cigar: Option<&CigarString>, seq: &[u8], qual: &[u8]) {
         self.cigar = None;
 
         self.inner_mut().l_data = (qname.len()
             + 1
-            + cigar.len() * 4
+            + if let Some(cigar_string) = cigar {
+                cigar_string.len()
+            } else {
+                0
+            } * 4
             + ((seq.len() as f32 / 2.0).ceil() as usize)
             + qual.len()) as i32;
 
@@ -301,14 +305,17 @@ impl Record {
         self.inner_mut().core.l_qname = i as u8;
 
         // cigar
-        {
-            let cigar_data =
-                unsafe { slice::from_raw_parts_mut(data[i..].as_ptr() as *mut u32, cigar.len()) };
-            for (i, c) in cigar.iter().enumerate() {
+        if let Some(cigar_string) = cigar {
+            let cigar_data = unsafe {
+                slice::from_raw_parts_mut(data[i..].as_ptr() as *mut u32, cigar_string.len())
+            };
+            for (i, c) in cigar_string.iter().enumerate() {
                 cigar_data[i] = c.encode();
             }
-            self.inner_mut().core.n_cigar = cigar.len() as u32;
-            i += cigar.len() * 4;
+            self.inner_mut().core.n_cigar = cigar_string.len() as u32;
+            i += cigar_string.len() * 4;
+        } else {
+            self.inner_mut().core.n_cigar = 0;
         }
 
         // seq


### PR DESCRIPTION
This PR makes the cigar parameter of a BAM record optional when setting variable length data.
Doing so allows to create unmapped records.