### PR TITLE
Store BCF field size in `TagLength::Fixed`

### DIFF
--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -289,7 +289,7 @@ impl BamRecordExtensions for bam::Record {
 mod tests {
     use crate::bam;
     use crate::bam::ext::BamRecordExtensions;
-    use crate::bam::record::{Cigar, CigarString, Record};
+    use crate::bam::record::{Cigar, CigarString};
     use crate::prelude::*;
     use std::collections::HashMap;
 

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1102,13 +1102,13 @@ mod tests {
                 // INFO=<ID=INDEL,Number=0,Type=Flag>
                 "INDEL",
                 header::TagType::Flag,
-                header::TagLength::Fixed,
+                header::TagLength::Fixed(0),
             ),
             (
                 // INFO=<ID=DP,Number=1,Type=Integer>
                 "DP",
                 header::TagType::Integer,
-                header::TagLength::Fixed,
+                header::TagLength::Fixed(1),
             ),
             (
                 // INFO=<ID=QS,Number=R,Type=Float>
@@ -1120,7 +1120,7 @@ mod tests {
                 // INFO=<ID=I16,Number=16,Type=Float>
                 "I16",
                 header::TagType::Float,
-                header::TagLength::Fixed,
+                header::TagLength::Fixed(16),
             ),
         ];
         for (ref_name, ref_type, ref_length) in truth {
@@ -1136,13 +1136,13 @@ mod tests {
                 // INFO=<ID=IMPRECISE,Number=0,Type=Flag>
                 "IMPRECISE",
                 header::TagType::Flag,
-                header::TagLength::Fixed,
+                header::TagLength::Fixed(0),
             ),
             (
                 // INFO=<ID=SVTYPE,Number=1,Type=String>
                 "SVTYPE",
                 header::TagType::String,
-                header::TagLength::Fixed,
+                header::TagLength::Fixed(1),
             ),
             (
                 // INFO=<ID=SVLEN,Number=.,Type=Integer>

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1094,6 +1094,79 @@ mod tests {
     }
 
     #[test]
+    fn test_header_info_types() {
+        let vcf = Reader::from_path(&"test/test.bcf").unwrap();
+        let header = vcf.header();
+        let truth = vec![
+            (
+                // INFO=<ID=INDEL,Number=0,Type=Flag>
+                "INDEL",
+                header::TagType::Flag,
+                header::TagLength::Fixed,
+            ),
+            (
+                // INFO=<ID=DP,Number=1,Type=Integer>
+                "DP",
+                header::TagType::Integer,
+                header::TagLength::Fixed,
+            ),
+            (
+                // INFO=<ID=QS,Number=R,Type=Float>
+                "QS",
+                header::TagType::Float,
+                header::TagLength::Alleles,
+            ),
+            (
+                // INFO=<ID=I16,Number=16,Type=Float>
+                "I16",
+                header::TagType::Float,
+                header::TagLength::Fixed,
+            ),
+        ];
+        for (ref_name, ref_type, ref_length) in truth {
+            let (tag_type, tag_length) = header.info_type(ref_name.as_bytes()).unwrap();
+            assert_eq!(tag_type, ref_type);
+            assert_eq!(tag_length, ref_length);
+        }
+
+        let vcf = Reader::from_path(&"test/test_svlen.vcf").unwrap();
+        let header = vcf.header();
+        let truth = vec![
+            (
+                // INFO=<ID=IMPRECISE,Number=0,Type=Flag>
+                "IMPRECISE",
+                header::TagType::Flag,
+                header::TagLength::Fixed,
+            ),
+            (
+                // INFO=<ID=SVTYPE,Number=1,Type=String>
+                "SVTYPE",
+                header::TagType::String,
+                header::TagLength::Fixed,
+            ),
+            (
+                // INFO=<ID=SVLEN,Number=.,Type=Integer>
+                "SVLEN",
+                header::TagType::Integer,
+                header::TagLength::Variable,
+            ),
+            (
+                // INFO<ID=CIGAR,Number=A,Type=String>
+                "CIGAR",
+                header::TagType::String,
+                header::TagLength::AltAlleles,
+            ),
+        ];
+        for (ref_name, ref_type, ref_length) in truth {
+            let (tag_type, tag_length) = header.info_type(ref_name.as_bytes()).unwrap();
+            assert_eq!(tag_type, ref_type);
+            assert_eq!(tag_length, ref_length);
+        }
+
+        assert!(header.info_type(b"NOT_THERE").is_err());
+    }
+
+    #[test]
     fn test_remove_alleles() {
         let mut bcf = Reader::from_path(&"test/test_multi.bcf").unwrap();
         for res in bcf.records() {


### PR DESCRIPTION
This PR extends the `TagLength::Fixed` enum to store the fixed number of fields defined in the B/VCF header. E.g. the size of the info header line ` INFO=<ID=I16,Number=16,Type=Float>` is now accessible as `TagLength::Fixed(16)`. I have found this very useful when parsing and validating VCF records. Getting the fixed field size comes with no additional compute costs, and fits well into the `TagLength` enum (note that the field size is not constant for variants other than `Fixed`). This also adds a number of test cases for tag type and length, based on the existing test files. 