### PR TITLE
Fix bam reader format checks for text inputs

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1611,7 +1611,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_bam_fails_on_toml() {
-        let bam_path = "./cargo.toml";
+        let bam_path = "./Cargo.toml";
         let bam_reader = Reader::from_path(bam_path);
         assert!(bam_reader.is_err());
     }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -782,7 +782,11 @@ fn hts_open(path: &ffi::CStr, mode: &[u8]) -> Result<*mut htslib::htsFile, BGZFE
     } else {
         if !mode.contains(&b'w') {
             unsafe {
-                if (*ret).format.category != htslib::htsFormatCategory_sequence_data {
+                // Comparison against 'htsFormatCategory_sequence_data' doesn't handle text files correctly
+                // hence the explicit checks against all supported exact formats
+                if (*ret).format.format != htslib::htsExactFormat_bam
+                    && (*ret).format.format != htslib::htsExactFormat_cram
+                {
                     return Err(BGZFError::Some);
                 }
             }


### PR DESCRIPTION
This PR extends the format checking in the BAM/CRAM reader from #132:

First of all, it fixes a typo in the test file name for `test_bam_fails_on_toml`. The test checks if an error is thrown. It passed before because the input file wasn't found, not the `BGZFError` we are expecting. After correcting the file name, this test didn't fail anymore - the toml file is not detected as an invalid input file for the BAM/CRAM reader.

Which brings us to part two: The validity check compared the format category against `htslib::htsFormatCategory_sequence_data`. The nasty problem is that htslib classifies most text inputs as SAM files (see [here](https://github.com/samtools/htslib/blob/5c7ff9c6812f1e6ef1fd83ba73b8e42cfbabba93/hts.c#L296-L305) for the underlying code, the FIXME comment has been there for a while). While this ultimately an upstream issue, a reasonable solution for now is to check against the exact formats, BAM and CRAM, explicitly.