### PR TITLE
Transition to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["htslib", "bam", "bioinformatics", "pileup", "sequencing"]
 license = "MIT"
 repository = "https://github.com/rust-bio/rust-htslib.git"
 documentation = "https://docs.rs/rust-htslib"
+edition = "2018"
 
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ Add this to your `Cargo.toml`:
 rust-htslib = "*"
 ```
 
-and this to your crate root:
-
-```rust
-extern crate rust_htslib;
-```
-
 For more information, please see the [docs](https://docs.rs/rust-htslib).
 
 # Authors
@@ -45,7 +39,7 @@ For more information, please see the [docs](https://docs.rs/rust-htslib).
 * [Patrick Marks](https://github.com/pmarks)
 * [David Lähnemann](https://github.com/dlaehnemann)
 * [Manuel Holtgrewe](https://github.com/holtgrewe)
-
+* [Julian Gehring](https://github.com/juliangehring)
 
 For other contributors, see [here](https://github.com/rust-bio/rust-htslib/graphs/contributors).
 

--- a/build.rs
+++ b/build.rs
@@ -3,10 +3,8 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate bindgen;
-extern crate cc;
-extern crate fs_utils;
-
+use bindgen;
+use cc;
 use fs_utils::copy::copy_directory;
 
 use std::env;

--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -7,8 +7,8 @@ use std::collections::{vec_deque, VecDeque};
 use std::error::Error;
 use std::str;
 
-use bam;
-use bam::Read;
+use crate::bam;
+use crate::bam::Read;
 
 /// A buffer for BAM records. This allows access regions in a sorted BAM file while iterating
 /// over it in a single pass.
@@ -59,7 +59,7 @@ impl RecordBuffer {
         chrom: &[u8],
         start: u32,
         end: u32,
-    ) -> Result<(usize, usize), Box<Error>> {
+    ) -> Result<(usize, usize), Box<dyn Error>> {
         let mut added = 0;
         // move overflow from last fetch into ringbuffer
         if self.overflow.is_some() {
@@ -125,12 +125,12 @@ impl RecordBuffer {
     }
 
     /// Iterate over records that have been fetched with `fetch`.
-    pub fn iter(&self) -> vec_deque::Iter<bam::Record> {
+    pub fn iter(&self) -> vec_deque::Iter<'_, bam::Record> {
         self.inner.iter()
     }
 
     /// Iterate over mutable references to records that have been fetched with `fetch`.
-    pub fn iter_mut(&mut self) -> vec_deque::IterMut<bam::Record> {
+    pub fn iter_mut(&mut self) -> vec_deque::IterMut<'_, bam::Record> {
         self.inner.iter_mut()
     }
 
@@ -152,7 +152,7 @@ quick_error! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bam;
+    use crate::bam;
     use itertools::Itertools;
 
     #[test]

--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -7,7 +7,7 @@
 
 use crate::bam;
 use crate::bam::record::Cigar;
-use htslib;
+use crate::htslib;
 use std::collections::HashMap;
 
 /// Extra functionality for BAM records

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -3,7 +3,7 @@
 // This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use bam::HeaderView;
+use crate::bam::HeaderView;
 use linear_map::LinearMap;
 use regex::Regex;
 use std::collections::HashMap;
@@ -41,7 +41,7 @@ impl Header {
     }
 
     /// Add a record to the header.
-    pub fn push_record(&mut self, record: &HeaderRecord) -> &mut Self {
+    pub fn push_record(&mut self, record: &HeaderRecord<'_>) -> &mut Self {
         self.records.push(record.to_bytes());
         self
     }

--- a/src/bam/index.rs
+++ b/src/bam/index.rs
@@ -8,8 +8,8 @@
 use std::path::Path;
 use std::ptr;
 
-use htslib;
-use utils;
+use crate::htslib;
+use crate::utils;
 
 /// Index type to build.
 pub enum Type {

--- a/src/bam/pileup.rs
+++ b/src/bam/pileup.rs
@@ -7,10 +7,10 @@ use std::fmt;
 use std::iter;
 use std::slice;
 
-use htslib;
+use crate::htslib;
 
-use bam;
-use bam::record;
+use crate::bam;
+use crate::bam::record;
 
 /// Iterator over alignments of a pileup.
 pub type Alignments<'a> = iter::Map<
@@ -40,7 +40,7 @@ impl Pileup {
         self.depth
     }
 
-    pub fn alignments(&self) -> Alignments {
+    pub fn alignments(&self) -> Alignments<'_> {
         self.inner().iter().map(Alignment::new)
     }
 
@@ -60,7 +60,7 @@ pub struct Alignment<'a> {
 }
 
 impl<'a> fmt::Debug for Alignment<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Alignment")
     }
 }
@@ -124,7 +124,7 @@ pub enum Indel {
 
 /// Iterator over pileups.
 #[derive(Debug)]
-pub struct Pileups<'a, R: 'a + bam::Read> {
+pub struct Pileups<'a, R: bam::Read> {
     #[allow(dead_code)]
     reader: &'a mut R,
     itr: htslib::bam_plp_t,
@@ -196,8 +196,8 @@ quick_error! {
 #[cfg(test)]
 mod tests {
 
-    use bam;
-    use prelude::*;
+    use crate::bam;
+    use crate::prelude::*;
 
     #[test]
     fn test_max_pileup() {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -14,9 +14,9 @@ use std::u32;
 
 use regex::Regex;
 
-use bam::{AuxWriteError, HeaderView, ReadError};
-use htslib;
-use utils;
+use crate::bam::{AuxWriteError, HeaderView, ReadError};
+use crate::htslib;
+use crate::utils;
 
 use bio_types::alignment::{Alignment, AlignmentMode, AlignmentOperation};
 use bio_types::sequence::SequenceRead;
@@ -88,7 +88,7 @@ impl PartialEq for Record {
 impl Eq for Record {}
 
 impl fmt::Debug for Record {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt.write_fmt(format_args!(
             "Record(tid: {}, pos: {})",
             self.tid(),
@@ -467,7 +467,7 @@ impl Record {
     }
 
     /// Get read sequence. Complexity: O(1).
-    pub fn seq(&self) -> Seq {
+    pub fn seq(&self) -> Seq<'_> {
         Seq {
             encoded: self.seq_data(),
             len: self.seq_len(),
@@ -483,7 +483,7 @@ impl Record {
     }
 
     /// Get auxiliary data (tags).
-    pub fn aux(&self, tag: &[u8]) -> Option<Aux> {
+    pub fn aux(&self, tag: &[u8]) -> Option<Aux<'_>> {
         let aux = unsafe {
             htslib::bam_aux_get(
                 self.inner,
@@ -513,7 +513,7 @@ impl Record {
 
     /// Add auxiliary data.
     /// push_aux() should never be called before set().
-    pub fn push_aux(&mut self, tag: &[u8], value: &Aux) -> Result<(), AuxWriteError> {
+    pub fn push_aux(&mut self, tag: &[u8], value: &Aux<'_>) -> Result<(), AuxWriteError> {
         let ctag = tag.as_ptr() as *mut i8;
         let ret = unsafe {
             match *value {
@@ -801,7 +801,7 @@ impl Cigar {
 }
 
 impl fmt::Display for Cigar {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt.write_fmt(format_args!("{}{}", self.len(), self.char()))
     }
 }
@@ -976,7 +976,7 @@ impl<'a> IntoIterator for &'a CigarString {
 }
 
 impl fmt::Display for CigarString {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         for op in self {
             fmt.write_fmt(format_args!("{}{}", op.len(), op.char()))?;
         }
@@ -1175,7 +1175,7 @@ impl<'a> IntoIterator for &'a CigarStringView {
 }
 
 impl fmt::Display for CigarStringView {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         self.inner.fmt(fmt)
     }
 }

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -4,7 +4,7 @@ use serde::de::{self, Deserialize, Deserializer, MapAccess, SeqAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
-use bam::record::Record;
+use crate::bam::record::Record;
 
 fn fix_l_extranul(rec: &mut Record) {
     let l_extranul = rec.qname().iter().rev().take_while(|x| **x == 0u8).count() as u8;
@@ -64,7 +64,7 @@ impl<'de> Deserialize<'de> for Record {
                 impl<'de> Visitor<'de> for FieldVisitor {
                     type Value = Field;
 
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                         formatter.write_str("expecting a bam field")
                     }
 
@@ -99,7 +99,7 @@ impl<'de> Deserialize<'de> for Record {
         impl<'de> Visitor<'de> for RecordVisitor {
             type Value = Record;
 
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 formatter.write_str("struct Record")
             }
 
@@ -306,9 +306,9 @@ impl<'de> Deserialize<'de> for Record {
 
 #[cfg(test)]
 mod tests {
-    use bam::record::Record;
-    use bam::Read;
-    use bam::Reader;
+    use crate::bam::record::Record;
+    use crate::bam::Read;
+    use crate::bam::Reader;
 
     use std::path::Path;
 

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -7,7 +7,7 @@ use std::collections::{vec_deque, VecDeque};
 use std::error::Error;
 use std::mem;
 
-use bcf::{self, Read};
+use crate::bcf::{self, Read};
 
 /// A buffer for BCF records. This allows access regions in a sorted BCF file while iterating
 /// over it in a single pass.
@@ -74,10 +74,10 @@ impl RecordBuffer {
         chrom: &[u8],
         start: u32,
         end: u32,
-    ) -> Result<(usize, usize), Box<Error>> {
+    ) -> Result<(usize, usize), Box<dyn Error>> {
         // TODO panic if start is left of previous start or we have moved past the given chrom
         // before.
-        let rid = try!(self.reader.header.name2rid(chrom));
+        let rid = r#try!(self.reader.header.name2rid(chrom));
         let mut added = 0;
         let mut deleted = 0;
 
@@ -168,12 +168,12 @@ impl RecordBuffer {
     }
 
     /// Iterate over records that have been fetched with `fetch`.
-    pub fn iter(&self) -> vec_deque::Iter<bcf::Record> {
+    pub fn iter(&self) -> vec_deque::Iter<'_, bcf::Record> {
         self.ringbuffer.iter()
     }
 
     /// Iterate over mutable references to records that have been fetched with `fetch`.
-    pub fn iter_mut(&mut self) -> vec_deque::IterMut<bcf::Record> {
+    pub fn iter_mut(&mut self) -> vec_deque::IterMut<'_, bcf::Record> {
         self.ringbuffer.iter_mut()
     }
 
@@ -185,7 +185,7 @@ impl RecordBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bcf;
+    use crate::bcf;
     use itertools::Itertools;
 
     #[test]

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -7,7 +7,7 @@ use std::ffi;
 use std::slice;
 use std::str;
 
-use htslib;
+use crate::htslib;
 
 use linear_map::LinearMap;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,11 +68,8 @@
 //! // afterwards, read or pileup in this region
 //! ```
 
-extern crate bitflags;
 #[macro_use]
 extern crate custom_derive;
-extern crate ieee754;
-extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
@@ -80,10 +77,6 @@ extern crate libc;
 extern crate newtype_derive;
 #[macro_use]
 extern crate quick_error;
-extern crate regex;
-extern crate url;
-
-extern crate linear_map;
 
 #[cfg(feature = "serde")]
 extern crate serde;
@@ -96,8 +89,6 @@ extern crate bincode;
 extern crate pretty_assertions;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_json;
-
-extern crate bio_types;
 
 extern crate libz_sys;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,5 +9,5 @@
 //! use rust_htslib::prelude::*;
 //! ```
 
-pub use bam::Read;
-pub use bcf::record::Numeric;
+pub use crate::bam::Read;
+pub use crate::bcf::record::Numeric;

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -8,11 +8,11 @@
 use std::ffi;
 use std::path::Path;
 
-use htslib;
+use crate::htslib;
 
-use bam::header;
-use bam::record;
-use bam::HeaderView;
+use crate::bam::header;
+use crate::bam::record;
+use crate::bam::HeaderView;
 
 /// SAM writer.
 #[derive(Debug)]
@@ -43,7 +43,7 @@ impl Writer {
         header: &header::Header,
     ) -> Result<Self, WriterError> {
         if let Some(p) = path.as_ref().to_str() {
-            Ok(try!(Self::new(p.as_bytes(), header)))
+            Ok(r#try!(Self::new(p.as_bytes(), header)))
         } else {
             Err(WriterError::IOError)
         }
@@ -59,7 +59,7 @@ impl Writer {
     }
 
     fn new(path: &[u8], header: &header::Header) -> Result<Self, WriterError> {
-        let f = try!(hts_open(&ffi::CString::new(path).unwrap(), b"w"));
+        let f = r#try!(hts_open(&ffi::CString::new(path).unwrap(), b"w"));
         let header_view = HeaderView::from_header(header);
 
         unsafe {
@@ -111,11 +111,11 @@ quick_error! {
 
 #[cfg(test)]
 mod tests {
-    use bam::header;
-    use bam::record;
-    use bam::Read;
-    use bam::Reader;
-    use sam::Writer;
+    use crate::bam::header;
+    use crate::bam::record;
+    use crate::bam::Read;
+    use crate::bam::Reader;
+    use crate::sam::Writer;
 
     #[test]
     fn test_sam_writer_example() {


### PR DESCRIPTION
Steps (analogous to https://github.com/rust-bio/rust-bio/pull/210):
- Run `cargo fix --all-features`
- Add the `edition="2018"` flag to `Cargo.toml`
- Run `cargo fix --edition-idioms --all-features`
- Fix cargo errors in `src/lib.rs` manually
- Run `cargo fmt`