### PR TITLE
Drop unused bcf::GT_MISSING constant

### DIFF
--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -27,9 +27,6 @@ use crate::htslib;
 pub use crate::bcf::header::{Header, HeaderRecord};
 pub use crate::bcf::record::Record;
 
-/// Redefinition of corresponding `#define` in `vcf.h.`.
-pub const GT_MISSING: i32 = 0;
-
 /// A trait for a BCF reader with a read method.
 pub trait Read: Sized {
     /// Read the next record.


### PR DESCRIPTION
Hardcoding the `GT_MISSING` constant in the `bcf` module doesn't seem to be needed any longer with newer htslib versions and, if needed, `htslib::bcf_gt_missing` can be used instead.