### PR TITLE
Code simplification and harmonisation

### DIFF
--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -14,6 +14,12 @@ pub struct Header {
     records: Vec<Vec<u8>>,
 }
 
+impl Default for Header {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Header {
     /// Create a new header.
     pub fn new() -> Self {
@@ -64,8 +70,8 @@ impl Header {
 
         let header_string = String::from_utf8(self.to_bytes()).unwrap();
 
-        for line in header_string.split("\n").filter(|x| x.len() > 0) {
-            let parts: Vec<_> = line.split("\t").filter(|x| x.len() > 0).collect();
+        for line in header_string.split('\n').filter(|x| !x.is_empty()) {
+            let parts: Vec<_> = line.split('\t').filter(|x| !x.is_empty()).collect();
             // assert!(rec_type_re.is_match(parts[0]));
             let record_type = rec_type_re
                 .captures(parts[0])
@@ -83,7 +89,7 @@ impl Header {
             }
             header_map
                 .entry(record_type)
-                .or_insert_with(|| Vec::new())
+                .or_insert_with(Vec::new)
                 .push(field);
         }
         header_map

--- a/src/bam/pileup.rs
+++ b/src/bam/pileup.rs
@@ -67,7 +67,7 @@ impl<'a> fmt::Debug for Alignment<'a> {
 
 impl<'a> Alignment<'a> {
     pub fn new(inner: &'a htslib::bam_pileup1_t) -> Self {
-        Alignment { inner: inner }
+        Alignment { inner }
     }
 
     /// Position within the read. None if either `is_del` or `is_refskip`.
@@ -132,10 +132,7 @@ pub struct Pileups<'a, R: bam::Read> {
 
 impl<'a, R: bam::Read> Pileups<'a, R> {
     pub fn new(reader: &'a mut R, itr: htslib::bam_plp_t) -> Self {
-        Pileups {
-            reader: reader,
-            itr: itr,
-        }
+        Pileups { reader, itr }
     }
 
     /// Warning: because htslib internally uses signed integer for depth this method
@@ -166,7 +163,7 @@ impl<'a, R: bam::Read> Iterator for Pileups<'a, R> {
             true if depth == -1 => Some(Err(PileupError::Some)),
             true => None,
             false => Some(Ok(Pileup {
-                inner: inner,
+                inner,
                 depth: depth as u32,
                 tid: tid as u32,
                 pos: pos as u32,

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -30,7 +30,7 @@ impl RecordBuffer {
     /// Create new buffer.
     pub fn new(reader: bcf::Reader) -> Self {
         RecordBuffer {
-            reader: reader,
+            reader,
             ringbuffer: VecDeque::new(),
             ringbuffer2: VecDeque::new(),
             overflow: None,

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -36,6 +36,12 @@ pub struct Header {
     pub subset: Option<SampleSubset>,
 }
 
+impl Default for Header {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Header {
     /// Create a new (empty) `Header`.
     pub fn new() -> Self {
@@ -88,7 +94,7 @@ impl Header {
             Err(SubsetError::DuplicateSampleName)
         } else {
             Ok(Header {
-                inner: inner,
+                inner,
                 subset: Some(imap),
             })
         }
@@ -232,7 +238,7 @@ pub struct HeaderView {
 
 impl HeaderView {
     pub fn new(inner: *mut htslib::bcf_hdr_t) -> Self {
-        HeaderView { inner: inner }
+        HeaderView { inner }
     }
 
     #[inline]

--- a/src/sam/mod.rs
+++ b/src/sam/mod.rs
@@ -66,7 +66,7 @@ impl Writer {
             htslib::sam_hdr_write(f, &header_view.inner());
         }
         Ok(Writer {
-            f: f,
+            f,
             header: header_view,
         })
     }

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -153,7 +153,7 @@ impl Reader {
         };
         unsafe {
             while htslib::hts_getline(hts_file, KS_SEP_LINE, &mut buf) >= 0 {
-                if buf.l > 0 && (*buf.s) as i32 == (*tbx).conf.meta_char {
+                if buf.l > 0 && i32::from(*buf.s) == (*tbx).conf.meta_char {
                     header.push(String::from(ffi::CStr::from_ptr(buf.s).to_str().unwrap()));
                 } else {
                     break;
@@ -367,7 +367,7 @@ impl ReadError {
     /// Returns true if no record has been read because the end of the file was reached.
     pub fn is_eof(&self) -> bool {
         match self {
-            &ReadError::NoMoreRecord => true,
+            ReadError::NoMoreRecord => true,
             _ => false,
         }
     }


### PR DESCRIPTION
A number of small code simplifications that should improve the readability and consistency. Most of them come from clippy warnings. All suggested changes are non-breaking - changes that would affect the user interface have been omitted here.