### PR TITLE
check for OOM during realloc & panic, rather than proceeding with null

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -388,7 +388,6 @@ impl Record {
     }
 
     fn realloc_var_data(&mut self, new_len: usize) {
-
         // pad request
         let new_len = new_len as u32;
         let new_request = new_len + 32 - (new_len % 32);
@@ -404,7 +403,7 @@ impl Record {
             panic!("ran out of memory in rust_htslib trying to realloc");
         }
 
-        // don't update m_data until we know we have 
+        // don't update m_data until we know we have
         // a successful allocation.
         self.inner_mut().m_data = new_request;
         self.inner_mut().data = ptr;


### PR DESCRIPTION
Will avoid segfault and be easier to diagnose issues if you run into OOM.