### PR TITLE
 breaking change: don't return Result<> from bam::Record::push_aux

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1222,7 +1222,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         rec.set(names[0], Some(&cigars[0]), seqs[0], quals[0]);
         // note: this segfaults if you push_aux() before set()
         //       because set() obliterates aux
-        rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
+        rec.push_aux(b"NM", &Aux::Integer(15));
 
         assert_eq!(rec.qname(), names[0]);
         assert_eq!(*rec.cigar(), cigars[0]);
@@ -1241,7 +1241,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         for i in 0..names.len() {
             let mut rec = record::Record::new();
             rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-            rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
+            rec.push_aux(b"NM", &Aux::Integer(15));
 
             assert_eq!(rec.qname(), names[i]);
             assert_eq!(*rec.cigar(), cigars[i]);
@@ -1354,7 +1354,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
                 rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-                rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
+                rec.push_aux(b"NM", &Aux::Integer(15));
 
                 bam.write(&mut rec).ok().expect("Failed to write record.");
             }
@@ -1406,7 +1406,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
                 rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
-                rec.push_aux(b"NM", &Aux::Integer(15)).unwrap();
+                rec.push_aux(b"NM", &Aux::Integer(15));
                 rec.set_pos(i as i32);
 
                 bam.write(&mut rec).ok().expect("Failed to write record.");

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -523,7 +523,7 @@ impl Record {
 
     /// Add auxiliary data.
     /// push_aux() should never be called before set().
-    pub fn push_aux(&mut self, tag: &[u8], value: &Aux<'_>) -> Result<(), AuxWriteError> {
+    pub fn push_aux(&mut self, tag: &[u8], value: &Aux<'_>) {
         let ctag = tag.as_ptr() as *mut i8;
         let ret = unsafe {
             match *value {
@@ -559,9 +559,7 @@ impl Record {
         };
 
         if ret < 0 {
-            Err(AuxWriteError::Some)
-        } else {
-            Ok(())
+            panic!("htslib ran out of memory in push_aux");
         }
     }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -388,7 +388,6 @@ impl Record {
     }
 
     fn realloc_var_data(&mut self, new_len: usize) {
-
         // pad request
         let new_len = new_len as u32;
         let new_request = new_len + 32 - (new_len % 32);
@@ -404,7 +403,7 @@ impl Record {
             panic!("ran out of memory in rust_htslib trying to realloc");
         }
 
-        // don't update m_data until we know we have 
+        // don't update m_data until we know we have
         // a successful allocation.
         self.inner_mut().m_data = new_request;
         self.inner_mut().data = ptr;


### PR DESCRIPTION
As discussed in #147.  Applies on top of #148.
