### PR TITLE
Add wrapper for bam_itr_querys

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -367,7 +367,8 @@ impl IndexedReader {
         if let Some(itr) = self.itr {
             unsafe { htslib::hts_itr_destroy(itr) }
         }
-        let itr = unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), region.as_ptr()) };
+        let itr = 
+            unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), region.as_ptr()) };
         if itr.is_null() {
             self.itr = None;
             Err(FetchError::Some)

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -373,8 +373,8 @@ impl IndexedReader {
             unsafe { htslib::hts_itr_destroy(itr) }
         }
         let rstr = ffi::CString::new(region).unwrap();
-        let itr =
-            unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), rstr.as_ptr()) };
+        let rptr = rstr.as_ptr();
+        let itr = unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), rptr) };
         if itr.is_null() {
             self.itr = None;
             Err(FetchError::Some)

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -363,6 +363,20 @@ impl IndexedReader {
         }
     }
 
+    pub fn fetch_str(&mut self, region: ffi::CString) -> Result<(), FetchError> {
+        if let Some(itr) = self.itr {
+            unsafe { htslib::hts_itr_destroy(itr) }
+        }
+        let itr = unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), region.as_ptr()) };
+        if itr.is_null() {
+            self.itr = None;
+            Err(FetchError::Some)
+        } else {
+            self.itr = Some(itr);
+            Ok(())
+        }
+    }
+
     extern "C" fn pileup_read(
         data: *mut ::std::os::raw::c_void,
         record: *mut htslib::bam1_t,

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -362,13 +362,19 @@ impl IndexedReader {
             Ok(())
         }
     }
-
-    pub fn fetch_str(&mut self, region: ffi::CString) -> Result<(), FetchError> {
+    /// Fetch reads from a region using a samtools region string.
+    /// Region strings are of the format b"chr1:1-1000".
+    ///
+    /// # Arguments
+    ///
+    /// * `region` - A binary string
+    pub fn fetch_str(&mut self, region: &[u8]) -> Result<(), FetchError> {
         if let Some(itr) = self.itr {
             unsafe { htslib::hts_itr_destroy(itr) }
         }
-        let itr = 
-            unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), region.as_ptr()) };
+        let rstr = ffi::CString::new(region).unwrap();
+        let itr =
+            unsafe { htslib::sam_itr_querys(self.idx, &mut self.header.inner(), rstr.as_ptr()) };
         if itr.is_null() {
             self.itr = None;
             Err(FetchError::Some)


### PR DESCRIPTION
Construct a new function for IndexedReader that wraps `bam_itr_querys` and allows for direct string queries. This allows for access to unmapped reads.