### PR TITLE
Avoid references when copying is more efficient

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -14,7 +14,7 @@ use std::u32;
 
 use regex::Regex;
 
-use crate::bam::{AuxWriteError, HeaderView, ReadError};
+use crate::bam::{HeaderView, ReadError};
 use crate::htslib;
 use crate::utils;
 
@@ -769,8 +769,8 @@ pub enum Cigar {
 }
 
 impl Cigar {
-    fn encode(&self) -> u32 {
-        match *self {
+    fn encode(self) -> u32 {
+        match self {
             Cigar::Match(len) => len << 4 | 0,
             Cigar::Ins(len) => len << 4 | 1,
             Cigar::Del(len) => len << 4 | 2,
@@ -784,8 +784,8 @@ impl Cigar {
     }
 
     /// Return the length of the CIGAR.
-    pub fn len(&self) -> u32 {
-        match *self {
+    pub fn len(self) -> u32 {
+        match self {
             Cigar::Match(len) => len,
             Cigar::Ins(len) => len,
             Cigar::Del(len) => len,
@@ -799,8 +799,8 @@ impl Cigar {
     }
 
     /// Return the character representing the CIGAR.
-    pub fn char(&self) -> char {
-        match *self {
+    pub fn char(self) -> char {
+        match self {
             Cigar::Match(_) => 'M',
             Cigar::Ins(_) => 'I',
             Cigar::Del(_) => 'D',

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1231,7 +1231,7 @@ mod tests {
             // Setup empty record, filled below.
             let mut record = writer.empty_record();
 
-            record.set_rid(&Some(0));
+            record.set_rid(Some(0));
             assert_eq!(record.rid().unwrap(), 0);
 
             record.set_pos(12);
@@ -1253,7 +1253,9 @@ mod tests {
             record.set_filters(&[header.name_to_id(b"q10").unwrap()]);
             record.push_filter(header.name_to_id(b"s50").unwrap());
             record.remove_filter(header.name_to_id(b"q10").unwrap(), true);
+            assert!(!record.has_filter(header.name_to_id(b"q10").unwrap()));
             record.push_filter(header.name_to_id(b"q10").unwrap());
+            assert!(record.has_filter(header.name_to_id(b"q10").unwrap()));
 
             record
                 .set_alleles(&["C".as_bytes(), "T".as_bytes(), "G".as_bytes()])

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -149,9 +149,9 @@ impl Record {
     }
 
     // Update the internal reference ID number.
-    pub fn set_rid(&mut self, rid: &Option<u32>) {
+    pub fn set_rid(&mut self, rid: Option<u32>) {
         match rid {
-            Some(rid) => self.inner_mut().rid = *rid as i32,
+            Some(rid) => self.inner_mut().rid = rid as i32,
             None => self.inner_mut().rid = -1,
         }
     }
@@ -238,12 +238,12 @@ impl Record {
     /// # Arguments
     ///
     /// - `flt_id` - The filter ID to query for.
-    pub fn has_filter(&self, flt_id: &Id) -> bool {
-        if **flt_id == 0 && self.inner().d.n_flt == 0 {
+    pub fn has_filter(&self, flt_id: Id) -> bool {
+        if *flt_id == 0 && self.inner().d.n_flt == 0 {
             return true;
         }
         for i in 0..(self.inner().d.n_flt as isize) {
-            if unsafe { *self.inner().d.flt.offset(i) } == **flt_id as i32 {
+            if unsafe { *self.inner().d.flt.offset(i) } == *flt_id as i32 {
                 return true;
             }
         }
@@ -638,9 +638,9 @@ impl GenotypeAllele {
     }
 
     /// Get the index into the list of alleles.
-    pub fn index(&self) -> Option<u32> {
+    pub fn index(self) -> Option<u32> {
         match self {
-            GenotypeAllele::Unphased(i) | GenotypeAllele::Phased(i) => Some(*i as u32),
+            GenotypeAllele::Unphased(i) | GenotypeAllele::Phased(i) => Some(i as u32),
             GenotypeAllele::UnphasedMissing | GenotypeAllele::PhasedMissing => None,
         }
     }


### PR DESCRIPTION
A number of small code simplifications which avoid unnecessary references, unneeded imports and add a few test cases. Please note that some of these are breaking changes.