### PR TITLE
fixing clippy lints (+breaking change)

### DIFF
--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -141,6 +141,10 @@ impl RecordBuffer {
     pub fn len(&self) -> usize {
         self.inner.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 #[cfg(test)]

--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -9123,6 +9123,7 @@ mod tests {
 
     #[test]
     fn test_infer_seq_len() {
+        use std::convert::TryFrom;
         let mut bam = bam::Reader::from_path("./test/test_spliced_reads.bam").unwrap();
         for read in bam.records() {
             let read = read.unwrap();
@@ -9145,7 +9146,7 @@ mod tests {
         ] {
             read.set(
                 b"test",
-                Some(&CigarString::from_str(input_cigar).unwrap()),
+                Some(&CigarString::try_from(input_cigar).unwrap()),
                 b"agtc",
                 b"BBBB",
             );

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -55,10 +55,7 @@ pub unsafe fn set_fai_filename<P: AsRef<Path>>(
     };
     let p: &Path = path.as_ref();
     let c_str = ffi::CString::new(p.to_str().unwrap().as_bytes()).unwrap();
-    if htslib::hts_set_fai_filename(
-        htsfile,c_str.as_ptr(),
-        ) == 0
-    {
+    if htslib::hts_set_fai_filename(htsfile, c_str.as_ptr()) == 0 {
         Ok(())
     } else {
         Err(Error::InvalidReferencePath { path: p.to_owned() })
@@ -318,8 +315,7 @@ impl IndexedReader {
         let htsfile = hts_open(path, b"r")?;
         let header = unsafe { htslib::sam_hdr_read(htsfile) };
         let c_str = ffi::CString::new(path).unwrap();
-        let idx =
-            unsafe { htslib::sam_index_load(htsfile, c_str.as_ptr()) };
+        let idx = unsafe { htslib::sam_index_load(htsfile, c_str.as_ptr()) };
         if idx.is_null() {
             Err(Error::InvalidIndex {
                 target: str::from_utf8(path).unwrap().to_owned(),
@@ -345,11 +341,7 @@ impl IndexedReader {
         let c_str_path = ffi::CString::new(path).unwrap();
         let c_str_index_path = ffi::CString::new(index_path).unwrap();
         let idx = unsafe {
-            htslib::sam_index_load2(
-                htsfile,
-                c_str_path.as_ptr(),
-                c_str_index_path.as_ptr(),
-            )
+            htslib::sam_index_load2(htsfile, c_str_path.as_ptr(), c_str_index_path.as_ptr())
         };
         if idx.is_null() {
             Err(Error::InvalidIndex {
@@ -713,8 +705,7 @@ fn hts_open(path: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
     let cpath = ffi::CString::new(path).unwrap();
     let path = str::from_utf8(path).unwrap();
     let c_str = ffi::CString::new(mode).unwrap();
-    let ret =
-        unsafe { htslib::hts_open(cpath.as_ptr(), c_str.as_ptr()) };
+    let ret = unsafe { htslib::hts_open(cpath.as_ptr(), c_str.as_ptr()) };
     if ret.is_null() {
         Err(Error::Open {
             target: path.to_owned(),
@@ -814,12 +805,7 @@ impl HeaderView {
 
     pub fn tid(&self, name: &[u8]) -> Option<u32> {
         let c_str = ffi::CString::new(name).expect("Expected valid name.");
-        let tid = unsafe {
-            htslib::bam_name2id(
-                self.inner,
-                c_str.as_ptr(),
-            )
-        };
+        let tid = unsafe { htslib::bam_name2id(self.inner, c_str.as_ptr()) };
         if tid < 0 {
             None
         } else {

--- a/src/bam/pileup.rs
+++ b/src/bam/pileup.rs
@@ -156,6 +156,7 @@ impl<'a, R: bam::Read> Pileups<'a, R> {
 impl<'a, R: bam::Read> Iterator for Pileups<'a, R> {
     type Item = Result<Pileup>;
 
+    #[allow(clippy::match_bool)]
     fn next(&mut self) -> Option<Result<Pileup>> {
         let (mut tid, mut pos, mut depth) = (0i32, 0i32, 0i32);
         let inner = unsafe { htslib::bam_plp_auto(self.itr, &mut tid, &mut pos, &mut depth) };

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -174,6 +174,10 @@ impl RecordBuffer {
     pub fn len(&self) -> usize {
         self.ringbuffer.len()
     }
+
+    pub fn is_empty(&self) -> bool{
+        self.len() == 0
+    }
 }
 
 #[cfg(test)]

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -175,7 +175,7 @@ impl RecordBuffer {
         self.ringbuffer.len()
     }
 
-    pub fn is_empty(&self) -> bool{
+    pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -107,9 +107,7 @@ impl Header {
     /// - `sample` - Name of the sample to add (to the end of the sample list).
     pub fn push_sample(&mut self, sample: &[u8]) -> &mut Self {
         let c_str = ffi::CString::new(sample).unwrap();
-        unsafe {
-            htslib::bcf_hdr_add_sample(self.inner, c_str.as_ptr())
-        };
+        unsafe { htslib::bcf_hdr_add_sample(self.inner, c_str.as_ptr()) };
         self
     }
 

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -136,7 +136,7 @@ impl Read for Reader {
     }
 
     fn set_threads(&mut self, n_threads: usize) -> Result<()> {
-       unsafe { set_threads(self.inner, n_threads)}
+        unsafe { set_threads(self.inner, n_threads) }
     }
 
     fn header(&self) -> &HeaderView {
@@ -504,7 +504,7 @@ pub mod synced {
         /// * `end` - `0`-based end coordinate of region on reference.
         pub fn fetch(&mut self, rid: u32, start: u32, end: u32) -> Result<()> {
             let contig = {
-                let contig = self.header(0).rid2name(rid).unwrap();//.clone();
+                let contig = self.header(0).rid2name(rid).unwrap(); //.clone();
                 ffi::CString::new(contig).unwrap()
             };
             if unsafe { htslib::bcf_sr_seek(self.inner, contig.as_ptr(), start as i32) } != 0 {

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -185,11 +185,7 @@ impl Record {
     pub fn set_id(&mut self, id: &[u8]) -> Result<()> {
         let c_str = ffi::CString::new(id).unwrap();
         if unsafe {
-            htslib::bcf_update_id(
-                self.header().inner,
-                self.inner,
-                c_str.as_ptr() as *mut i8,
-            )
+            htslib::bcf_update_id(self.header().inner, self.inner, c_str.as_ptr() as *mut i8)
         } == 0
         {
             Ok(())
@@ -202,11 +198,7 @@ impl Record {
     pub fn clear_id(&mut self) -> Result<()> {
         let c_str = ffi::CString::new(&b"."[..]).unwrap();
         if unsafe {
-            htslib::bcf_update_id(
-                self.header().inner,
-                self.inner,
-                c_str.as_ptr() as *mut i8,
-            )
+            htslib::bcf_update_id(self.header().inner, self.inner, c_str.as_ptr() as *mut i8)
         } == 0
         {
             Ok(())
@@ -218,13 +210,8 @@ impl Record {
     /// Add the ID string (the ID field is semicolon-separated), checking for duplicates.
     pub fn push_id(&mut self, id: &[u8]) -> Result<()> {
         let c_str = ffi::CString::new(id).unwrap();
-        if unsafe {
-            htslib::bcf_add_id(
-                self.header().inner,
-                self.inner,
-                c_str.as_ptr() as *mut i8,
-            )
-        } == 0
+        if unsafe { htslib::bcf_add_id(self.header().inner, self.inner, c_str.as_ptr() as *mut i8) }
+            == 0
         {
             Ok(())
         } else {

--- a/src/htslib.rs
+++ b/src/htslib.rs
@@ -1,8 +1,8 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
-
+#![allow(clippy::all)]
+#![allow(improper_ctypes)]
 //! This module exposes the raw Htslib bindings.
-
 // include on-the-fly generated bindings
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -151,8 +151,7 @@ impl Reader {
     fn new(path: &[u8]) -> Result<Self> {
         let path = ffi::CString::new(path).unwrap();
         let c_str = ffi::CString::new("r").unwrap();
-        let hts_file =
-            unsafe { htslib::hts_open(path.as_ptr(), c_str.as_ptr()) };
+        let hts_file = unsafe { htslib::hts_open(path.as_ptr(), c_str.as_ptr()) };
         unsafe {
             if (*hts_file).format.category != htslib::htsFormatCategory_region_list
                 && (*hts_file).format.format != htslib::htsExactFormat_sam
@@ -199,12 +198,7 @@ impl Reader {
     /// Get sequence/target ID from sequence name.
     pub fn tid(&self, name: &str) -> Result<u32> {
         let name_cstr = ffi::CString::new(name.as_bytes()).unwrap();
-        let res = unsafe {
-            htslib::tbx_name2id(
-                self.tbx,
-                name_cstr.as_ptr(),
-            )
-        };
+        let res = unsafe { htslib::tbx_name2id(self.tbx, name_cstr.as_ptr()) };
         if res < 0 {
             Err(Error::UnknownSequence {
                 sequence: name.to_owned(),
@@ -301,7 +295,7 @@ impl Read for Reader {
                             //mem::transmute(&mut self.buf),
                             &mut self.buf as *mut htslib::__kstring_t as *mut libc::c_void,
                             //mem::transmute(self.tbx),
-                            self.tbx as *mut libc::c_void
+                            self.tbx as *mut libc::c_void,
                         )
                     };
                     // Handle errors first.


### PR DESCRIPTION
This makes clippy useful for rust-htslib,
by making it shut up about the bindgen generated code,
and fixing all the minor suggestions it had.

The only visible change is that CigarString::from_bytes
and CigarString::from_str become TryFrom trait implementations.
Under todays rust, they were arguably misnamed (idiomatic frotm mustn't fail)
and should've been From/TryFrom implementations.
This means that users need to convert from CigarString::from_bytes(x) to
CigarString::try_from(x), but the functionality is untouched.