### PR TITLE
expand version compatibiltiy of snafu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1.3"
 linear-map = "1.2"
 serde = { version = "^1", optional = true }
 bio-types = ">=0.5.1"
-snafu = "0.5"
+snafu = ">= 0.5.0, <= 0.6.0"
 
 [features]
 default = ["bzip2", "lzma"]


### PR DESCRIPTION
This allows users of rust-htslib to upgrade to syn/quote 1.0, and eliminate a dependency on syn 0.15 which tends to take a lot of compile time.