### PR TITLE
update bindgen for better compat with rust v1.39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ pretty_assertions = "0.6"
 
 [build-dependencies]
 fs-utils = "1.1"
-bindgen = "0.51.0"
+bindgen = "0.52.0"
 cc = "1.0"


### PR DESCRIPTION
We ran into some issues with the 0.51 versions of bindgen on our rust 1.39 deployment, the latest (0.52) seems to fix them.

Would appreciate if we could upstream this.

If you prefer, I can update this to something like the following constraint instead: `>= 0.51.0, <= 0.52.0`, just let me know.

Many Thanks, and Happy Holidays!