### PR TITLE
inline bam1_t into bam::Record

### DIFF
--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -259,7 +259,7 @@ impl BamRecordExtensions for bam::Record {
         self.pos()
     }
     fn reference_end(&self) -> i32 {
-        unsafe { htslib::bam_endpos(self.inner) }
+        unsafe { htslib::bam_endpos(self.inner_ptr()) }
     }
 
     fn seq_len_from_cigar(&self, include_hard_clip: bool) -> usize {

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -148,8 +148,7 @@ impl<'de> Deserialize<'de> for Record {
 
                 let mut rec = Record::new();
                 {
-                    let _m = rec.inner_mut();
-                    let m = &mut _m.core;
+                    let m = &mut rec.inner_mut().core;
                     m.tid = tid;
                     m.pos = pos;
                     m.bin = bin;
@@ -279,8 +278,7 @@ impl<'de> Deserialize<'de> for Record {
 
                 let mut rec = Record::new();
                 {
-                    let _m = rec.inner_mut();
-                    let m = &mut _m.core;
+                    let m = &mut rec.inner_mut().core;
                     m.tid = tid;
                     m.pos = pos;
                     m.bin = bin;

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -253,7 +253,7 @@ impl Reader {
             }
         }
         unsafe {
-            libc::free(seqs as (*mut libc::c_void));
+            libc::free(seqs as *mut libc::c_void);
         };
 
         result


### PR DESCRIPTION
This may be a bit controversial, but because (on 64-bit platforms) `bam1_t` is just 52 bytes (54 if not BAM_NO_ID), it doesn't make much sense to incur the pointer indirection/allocation/fragmentation all the time rather than just keeping them around on the stack.

I will work on some benchmarks to give this greater context, but I did want to put it here for greater discussion.

It does mean the `from_inner(inner: *mut htslib::bam1_t)` constructor is a bit weird now--it copies the data over but keeps using the old `data` ptr until the next re-alloc, when `own` becomes `true`.