### PR TITLE
don't use default bindgen features -- cuts down on dependency list

### DIFF
--- a/hts-sys/Cargo.toml
+++ b/hts-sys/Cargo.toml
@@ -29,6 +29,6 @@ lzma = ["lzma-sys"]
 
 [build-dependencies]
 fs-utils = "1.1"
-bindgen = "0.52.0"
+bindgen = { version = "0.52.0", default-features = false }
 cc = "1.0"
 glob = "0.3.0"

--- a/hts-sys/Cargo.toml
+++ b/hts-sys/Cargo.toml
@@ -29,6 +29,6 @@ lzma = ["lzma-sys"]
 
 [build-dependencies]
 fs-utils = "1.1"
-bindgen = { version = "0.52.0", default-features = false }
+bindgen = { version = "0.52.0", default-features = false, features = ["runtime"] }
 cc = "1.0"
 glob = "0.3.0"

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1027,11 +1027,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
             .ok()
             .expect("Error opening file.");
 
-        let true_header =
-            "@SQ\tSN:CHROMOSOME_I\tLN:15072423\n@SQ\tSN:CHROMOSOME_II\tLN:15279345\
+        let true_header = "@SQ\tSN:CHROMOSOME_I\tLN:15072423\n@SQ\tSN:CHROMOSOME_II\tLN:15279345\
              \n@SQ\tSN:CHROMOSOME_III\tLN:13783700\n@SQ\tSN:CHROMOSOME_IV\tLN:17493793\n@SQ\t\
              SN:CHROMOSOME_V\tLN:20924149\n"
-                .to_string();
+            .to_string();
         let header_text = String::from_utf8(bam.header.as_bytes().to_owned()).unwrap();
         assert_eq!(header_text, true_header);
     }


### PR DESCRIPTION
removes a few dependencies, particularly `clap` which takes a while to compile.