### PR TITLE
when including hts-sys, don't use default features -- let the outer r…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde_base = { version = "^1", optional = true, package = "serde" }
 serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.5.1"
 snafu = ">= 0.5.0, <= 0.6.0"
-hts-sys = { version = "^1.9", path = "hts-sys" }
+hts-sys = { version = "^1.9", path = "hts-sys", default-features = false }
 
 [features]
 default = ["bzip2", "lzma"]

--- a/README.md
+++ b/README.md
@@ -24,10 +24,24 @@ To compile this crate you need the development headers of zlib, bzip2 and xz.
 ## Usage
 
 Add this to your `Cargo.toml`:
-
 ```toml
 [dependencies]
 rust-htslib = "*"
+```
+
+By default `rust-htslib` links to `bzip2-sys` and `lzma-sys` for full CRAM support. If you do not need CRAM support, or you do need to support CRAM files
+with these compression methods, you can deactivate these features to reduce you dependency count:
+
+```toml
+[dependencies]
+rust-htslib = { version = "*", default-features = false }
+```
+
+`rust-htslib` also has optional support for `serde`, to allow (de)serialization of `bam::Record` via any serde-supported format:
+
+```toml
+[dependencies]
+rust-htslib = { version = "*", features = ["serde"] }
 ```
 
 For more information, please see the [docs](https://docs.rs/rust-htslib).


### PR DESCRIPTION
 let the outer rust-htslib crate control them.  Without this change, there's no way to turn off usage of lzma and bzip which aren't needed if only BAM support is needed.