### PR TITLE
Allow building in a local install

### DIFF
--- a/hts-sys/Cargo.toml
+++ b/hts-sys/Cargo.toml
@@ -36,3 +36,4 @@ fs-utils = "1.1"
 bindgen = { version = "0.53.2", default-features = false, features = ["runtime"] }
 cc = "1.0"
 glob = "0.3.0"
+dirs = "1.0.2"

--- a/hts-sys/build.rs
+++ b/hts-sys/build.rs
@@ -132,16 +132,6 @@ fn main() {
         panic!("failed to build htslib");
     }
 
-    if !Command::new("make")
-        .current_dir(out.join("htslib"))
-        .arg("install")
-        .status()
-        .unwrap()
-        .success()
-    {
-        panic!("failed to build htslib");
-    }
-
     cfg.file("wrapper.c").compile("wrapper");
 
     bindgen::Builder::default()

--- a/hts-sys/build.rs
+++ b/hts-sys/build.rs
@@ -91,20 +91,6 @@ fn main() {
 
         &&    
 
-        !Command::new("autoconf")
-        .current_dir(out.join("htslib"))
-        .status().unwrap().success()
-
-        &&
-
-        !Command::new("./configure")
-        .current_dir(out.join("htslib"))
-        .env("CFLAGS", &cc_cflags)
-        .arg(format!("--host={}", &host))
-        .status().unwrap().success()
-
-        &&
-
         !Command::new("autoreconf")
         .current_dir(out.join("htslib"))
         .env("CFLAGS", &cc_cflags)
@@ -114,6 +100,8 @@ fn main() {
        
         !Command::new("./configure")
         .current_dir(out.join("htslib"))
+        .env("CFLAGS", &cc_cflags)
+        .arg(format!("--host={}", &host)) 
         .arg(format!("--prefix={}/local", home_dir().unwrap().into_os_string().into_string().unwrap()))
         .status().unwrap().success()
     {


### PR DESCRIPTION
Works on Mac OS and without sudo account.

Building the dependency `hts-sys/htslib` with Make does not work in Mac OS Mojave (10.14) or later. This enables installation of a local copy which essentially runs the configuration with one of these lines depending on the OS. 

```
./configure --prefix=/Users/$USER/local
./configure --prefix=/home/$USER/local
```

Note: this has not been tested on Windows.