### PR TITLE
Use `std` instead of `itertools` for collecting vectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ tag-message = "Version {{version}} of Rust-HTSlib."
 
 [dependencies]
 libc = "0.2"
-itertools = "0.9.0"
 newtype_derive = "0.1"
 custom_derive = "0.1"
 url = "2.1"

--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -151,7 +151,6 @@ impl RecordBuffer {
 mod tests {
     use super::*;
     use crate::bam;
-    use itertools::Itertools;
 
     #[test]
     fn test_buffer() {
@@ -161,7 +160,7 @@ mod tests {
 
         buffer.fetch(b"CHROMOSOME_I", 1, 5).unwrap();
         {
-            let records = buffer.iter().collect_vec();
+            let records: Vec<_> = buffer.iter().collect();
             assert_eq!(records.len(), 6);
             assert_eq!(records[0].pos(), 1);
             assert_eq!(records[1].pos(), 1);

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -184,7 +184,6 @@ impl RecordBuffer {
 mod tests {
     use super::*;
     use crate::bcf;
-    use itertools::Itertools;
 
     #[test]
     fn test_buffer() {
@@ -193,7 +192,7 @@ mod tests {
 
         buffer.fetch(b"1", 100, 10023).unwrap();
         {
-            let records = buffer.iter().collect_vec();
+            let records: Vec<_> = buffer.iter().collect();
             assert_eq!(records.len(), 2);
             assert_eq!(records[0].pos(), 10021);
             assert_eq!(records[1].pos(), 10022);
@@ -201,7 +200,7 @@ mod tests {
 
         buffer.fetch(b"1", 10023, 10024).unwrap();
         {
-            let records = buffer.iter().collect_vec();
+            let records: Vec<_> = buffer.iter().collect();
             assert_eq!(records.len(), 1);
             assert_eq!(records[0].pos(), 10023);
         }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -15,7 +15,6 @@ use std::str;
 
 use bio_types::genome;
 use ieee754::Ieee754;
-use itertools::Itertools;
 
 use crate::bcf::errors::Result;
 use crate::bcf::header::{HeaderView, Id};
@@ -715,7 +714,7 @@ impl<'a> Genotypes<'a> {
         Genotype(
             igt.iter()
                 .map(|&e| GenotypeAllele::from_encoded(e))
-                .collect_vec(),
+                .collect(),
         )
     }
 }


### PR DESCRIPTION
`itertools` is only used to collect into vectors. We can use `std` instead.