### PR TITLE
Use reference counted records in read buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ linear-map = "1.2"
 serde_base = { version = "^1", optional = true, package = "serde" }
 serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.6"
-snafu = "0.6"
 thiserror = "1"
 hts-sys = { version = "^1.10", path = "hts-sys", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_base = { version = "^1", optional = true, package = "serde" }
 serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.6"
 snafu = "0.6"
+thiserror = "1"
 hts-sys = { version = "^1.10", path = "hts-sys", default-features = false }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ linear-map = "1.2"
 serde_base = { version = "^1", optional = true, package = "serde" }
 serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.6"
-snafu = "0.6.8"
+snafu = "0.6"
 hts-sys = { version = "^1.10", path = "hts-sys", default-features = false }
 
 [features]

--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -4,8 +4,8 @@
 // except according to those terms.
 
 use std::collections::{vec_deque, VecDeque};
-use std::str;
 use std::rc::Rc;
+use std::str;
 
 use crate::bam;
 use crate::bam::errors::{Error, Result};

--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -130,12 +130,12 @@ impl RecordBuffer {
     }
 
     /// Iterate over records that have been fetched with `fetch`.
-    pub fn iter(&self) -> vec_deque::Iter<'_, Rc<bam::Record>> {
+    pub fn iter<'a>(&'a self) -> vec_deque::Iter<'a, Rc<bam::Record>> {
         self.inner.iter()
     }
 
     /// Iterate over mutable references to records that have been fetched with `fetch`.
-    pub fn iter_mut(&mut self) -> vec_deque::IterMut<'_, Rc<bam::Record>> {
+    pub fn iter_mut<'a>(&'a mut self) -> vec_deque::IterMut<'a, Rc<bam::Record>> {
         self.inner.iter_mut()
     }
 

--- a/src/bam/errors.rs
+++ b/src/bam/errors.rs
@@ -6,25 +6,25 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("error parsing CIGAR string: {msg:?}")]
+    #[error("error parsing CIGAR string: {msg}")]
     ParseCigar { msg: String },
-    #[error("unexpected CIGAR operation: {msg:?}")]
+    #[error("unexpected CIGAR operation: {msg}")]
     UnexpectedCigarOperation { msg: String },
-    #[error("error parsing SAM record: {rec:?}")]
+    #[error("error parsing SAM record: {rec}")]
     ParseSAM { rec: String },
     #[error("error setting threads for writing SAM/BAM/CRAM file(s)")]
     SetThreads,
-    #[error("invalid reference path {path:?}")]
+    #[error("invalid reference path {path}")]
     InvalidReferencePath { path: PathBuf },
-    #[error("invalid compression level {level:?}")]
+    #[error("invalid compression level {level}")]
     InvalidCompressionLevel { level: u32 },
-    #[error("file not found: {path:?}")]
+    #[error("file not found: {path}")]
     FileNotFound { path: PathBuf },
     #[error("invalid (non-unique) characters in path")]
     NonUnicodePath,
-    #[error("unable to open SAM/BAM/CRAM file at {target:?}")]
+    #[error("unable to open SAM/BAM/CRAM file at {target}")]
     Open { target: String },
-    #[error("unable to open SAM/BAM/CRAM index for {target:?}")]
+    #[error("unable to open SAM/BAM/CRAM index for {target}")]
     InvalidIndex { target: String },
     #[error("failed to write SAM/BAM/CRAM record (out of disk space?)")]
     Write,
@@ -36,7 +36,7 @@ pub enum Error {
     Fetch,
     #[error("error seeking to offset in SAM/BAM/CRAM file")]
     Seek,
-    #[error("sequence {sequence:?} not found in SAM/BAM/CRAM file header")]
+    #[error("sequence {sequence} not found in SAM/BAM/CRAM file header")]
     UnknownSequence { sequence: String },
     #[error("format of SAM files are not indexable")]
     NotIndexable,

--- a/src/bam/errors.rs
+++ b/src/bam/errors.rs
@@ -1,49 +1,49 @@
-use snafu::Snafu;
 use std::path::PathBuf;
+
+use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Snafu, Debug, PartialEq)]
-#[snafu(visibility = "pub")]
+#[derive(Error, Debug)]
 pub enum Error {
-    #[snafu(display("error parsing CIGAR string: {}", msg))]
+    #[error("error parsing CIGAR string: {msg:?}")]
     ParseCigar { msg: String },
-    #[snafu(display("unexpected CIGAR operation: {}", msg))]
+    #[error("unexpected CIGAR operation: {msg:?}")]
     UnexpectedCigarOperation { msg: String },
-    #[snafu(display("error parsing SAM record: {}", rec))]
+    #[error("error parsing SAM record: {rec:?}")]
     ParseSAM { rec: String },
-    #[snafu(display("error setting threads for writing SAM/BAM/CRAM file(s)"))]
+    #[error("error setting threads for writing SAM/BAM/CRAM file(s)")]
     SetThreads,
-    #[snafu(display("invalid reference path {}", path.display()))]
+    #[error("invalid reference path {path:?}")]
     InvalidReferencePath { path: PathBuf },
-    #[snafu(display("invalid compression level {}", level))]
+    #[error("invalid compression level {level:?}")]
     InvalidCompressionLevel { level: u32 },
-    #[snafu(display("file not found: {}", path.display()))]
+    #[error("file not found: {path:?}")]
     FileNotFound { path: PathBuf },
-    #[snafu(display("invalid (non-unique) characters in path"))]
+    #[error("invalid (non-unique) characters in path")]
     NonUnicodePath,
-    #[snafu(display("unable to open SAM/BAM/CRAM file at {}", target))]
+    #[error("unable to open SAM/BAM/CRAM file at {target:?}")]
     Open { target: String },
-    #[snafu(display("unable to open SAM/BAM/CRAM index for {}", target))]
+    #[error("unable to open SAM/BAM/CRAM index for {target:?}")]
     InvalidIndex { target: String },
-    #[snafu(display("failed to write SAM/BAM/CRAM record (out of disk space?)"))]
+    #[error("failed to write SAM/BAM/CRAM record (out of disk space?)")]
     Write,
-    #[snafu(display("invalid record in SAM/BAM/CRAM file"))]
+    #[error("invalid record in SAM/BAM/CRAM file")]
     InvalidRecord,
-    #[snafu(display("truncated record in SAM/BAM/CRAM file"))]
+    #[error("truncated record in SAM/BAM/CRAM file")]
     TruncatedRecord,
-    #[snafu(display("error fetching region in SAM/BAM/CRAM file"))]
+    #[error("error fetching region in SAM/BAM/CRAM file")]
     Fetch,
-    #[snafu(display("error seeking to offset in SAM/BAM/CRAM file"))]
+    #[error("error seeking to offset in SAM/BAM/CRAM file")]
     Seek,
-    #[snafu(display("sequence {} not found in SAM/BAM/CRAM file header", sequence))]
+    #[error("sequence {sequence:?} not found in SAM/BAM/CRAM file header")]
     UnknownSequence { sequence: String },
-    #[snafu(display("format of SAM files are not indexable"))]
+    #[error("format of SAM files are not indexable")]
     NotIndexable,
-    #[snafu(display("failed to write BAM/CRAM index (out of disk space?)"))]
+    #[error("failed to write BAM/CRAM index (out of disk space?)")]
     WriteIndex,
-    #[snafu(display("failed to build BAM/CRAM index"))]
+    #[error("failed to build BAM/CRAM index")]
     BuildIndex,
-    #[snafu(display("failed to create SAM/BAM/CRAM pileup"))]
+    #[error("failed to create SAM/BAM/CRAM pileup")]
     Pileup,
 }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1166,6 +1166,28 @@ impl CigarStringView {
         })
     }
 
+    /// Get number of bases hardclipped at the beginning of the alignment.
+    pub fn leading_hardclips(&self) -> i64 {
+        self.first().map_or(0, |cigar| {
+            if let Cigar::HardClip(s) = cigar {
+                *s as i64
+            } else {
+                0
+            }
+        })
+    }
+
+    /// Get number of bases hardclipped at the end of the alignment.
+    pub fn trailing_hardclips(&self) -> i64 {
+        self.last().map_or(0, |cigar| {
+            if let Cigar::HardClip(s) = cigar {
+                *s as i64
+            } else {
+                0
+            }
+        })
+    }
+
     /// For a given position in the reference, get corresponding position within read.
     /// If reference position is outside of the read alignment, return None.
     ///

--- a/src/bcf/errors.rs
+++ b/src/bcf/errors.rs
@@ -1,46 +1,43 @@
-use snafu::Snafu;
+use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Snafu, Debug, PartialEq)]
-#[snafu(visibility = "pub")]
+#[derive(Error, Debug)]
 pub enum Error {
-    #[snafu(display(
-        "error allocating internal data structure for BCF/VCF reader (out of memory?)"
-    ))]
+    #[error("error allocating internal data structure for BCF/VCF reader (out of memory?)")]
     AllocationError,
-    #[snafu(display("failed to open BCF/VCF from {}", target))]
+    #[error("failed to open BCF/VCF from {target:?}")]
     Open { target: String },
-    #[snafu(display("invalid record in BCF/VCF file"))]
+    #[error("invalid record in BCF/VCF file")]
     InvalidRecord,
-    #[snafu(display("error setting threads for writing BCF/VCF file(s)"))]
+    #[error("error setting threads for writing BCF/VCF file(s)")]
     SetThreads,
-    #[snafu(display("error seeking to {}:{} in indexed BCF/VCF file", contig, start))]
+    #[error("error seeking to {contig:?}:{start} in indexed BCF/VCF file")]
     Seek { contig: String, start: u64 },
-    #[snafu(display("error writing record to BCF/VCF file"))]
+    #[error("error writing record to BCF/VCF file")]
     Write,
-    #[snafu(display("tag {} undefined in BCF/VCF header", tag))]
+    #[error("tag {tag} undefined in BCF/VCF header")]
     UndefinedTag { tag: String },
-    #[snafu(display("unexpected type for tag {} BCF/VCF file", tag))]
+    #[error("unexpected type for tag {tag} BCF/VCF file")]
     UnexpectedType { tag: String },
-    #[snafu(display("tag {} missing from record {} in BCF/VCF file", tag, record))]
+    #[error("tag {tag} missing from record {record} in BCF/VCF file")]
     MissingTag { tag: String, record: String },
-    #[snafu(display("error setting tag {} in BCF/VCF record (out of memory?)", tag))]
+    #[error("error setting tag {tag} in BCF/VCF record (out of memory?)")]
     SetTag { tag: String },
-    #[snafu(display("ID {} not found in BCF/VCF header", rid))]
+    #[error("ID {rid} not found in BCF/VCF header")]
     UnknownRID { rid: u32 },
-    #[snafu(display("contig {} not found in BCF/VCF header", contig))]
+    #[error("contig {contig} not found in BCF/VCF header")]
     UnknownContig { contig: String },
-    #[snafu(display("ID {} not found in BCF/VCF header", id))]
+    #[error("ID {id} not found in BCF/VCF header")]
     UnknownID { id: String },
-    #[snafu(display("sample {} not found in BCF/VCF header", name))]
+    #[error("sample {name} not found in BCF/VCF header")]
     UnknownSample { name: String },
-    #[snafu(display("duplicate sample names given for subsetting BCF/VCF"))]
+    #[error("duplicate sample names given for subsetting BCF/VCF")]
     DuplicateSampleNames,
-    #[snafu(display("invalid (non-unique) characters in path"))]
+    #[error("invalid (non-unique) characters in path")]
     NonUnicodePath,
-    #[snafu(display("failed to set values in BCF/VCF record (out of memory?)"))]
+    #[error("failed to set values in BCF/VCF record (out of memory?)")]
     SetValues,
-    #[snafu(display("failed to remove alleles in BCF/VCF record"))]
+    #[error("failed to remove alleles in BCF/VCF record")]
     RemoveAlleles,
 }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -358,7 +358,7 @@ pub mod synced {
     impl SyncedReader {
         pub fn new() -> Result<Self> {
             let inner = unsafe { crate::htslib::bcf_sr_init() };
-            ensure!(!inner.is_null(), errors::AllocationError);
+            ensure!(!inner.is_null(), errors::Error::AllocationError);
 
             Ok(SyncedReader {
                 inner,
@@ -392,7 +392,7 @@ pub mod synced {
 
                     ensure!(
                         res != 0,
-                        errors::Open {
+                        errors::Error::Open {
                             target: p.to_owned()
                         }
                     );
@@ -430,7 +430,10 @@ pub mod synced {
             let num = unsafe { crate::htslib::bcf_sr_next_line(self.inner) as u32 };
 
             if num == 0 {
-                ensure!(unsafe { (*self.inner).errnum } == 0, errors::InvalidRecord);
+                ensure!(
+                    unsafe { (*self.inner).errnum } == 0,
+                    errors::Error::InvalidRecord
+                );
                 Ok(0)
             } else {
                 assert!(num > 0, "num returned by htslib must not be negative");
@@ -710,7 +713,7 @@ fn bcf_open(target: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
 
     ensure!(
         !ret.is_null(),
-        errors::Open {
+        errors::Error::Open {
             target: str::from_utf8(target).unwrap().to_owned()
         }
     );
@@ -719,7 +722,7 @@ fn bcf_open(target: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
         ensure!(
             mode.contains(&b'w')
                 || (*ret).format.category == htslib::htsFormatCategory_variant_data,
-            errors::Open {
+            errors::Error::Open {
                 target: str::from_utf8(target).unwrap().to_owned()
             }
         );

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -16,7 +16,6 @@ use std::path::Path;
 use std::rc::Rc;
 use std::str;
 
-use snafu::ensure;
 use url::Url;
 
 pub mod buffer;
@@ -358,7 +357,9 @@ pub mod synced {
     impl SyncedReader {
         pub fn new() -> Result<Self> {
             let inner = unsafe { crate::htslib::bcf_sr_init() };
-            ensure!(!inner.is_null(), errors::Error::AllocationError);
+            if inner.is_null() {
+                return Err(errors::Error::AllocationError);
+            }
 
             Ok(SyncedReader {
                 inner,
@@ -390,12 +391,11 @@ pub mod synced {
                     let res =
                         unsafe { crate::htslib::bcf_sr_add_reader(self.inner, p_cstring.as_ptr()) };
 
-                    ensure!(
-                        res != 0,
-                        errors::Error::Open {
-                            target: p.to_owned()
-                        }
-                    );
+                    if res == 0 {
+                        return Err(errors::Error::Open {
+                            target: p.to_owned(),
+                        });
+                    }
 
                     let i = (self.reader_count() - 1) as isize;
                     let header = Rc::new(HeaderView::new(unsafe {
@@ -430,10 +430,9 @@ pub mod synced {
             let num = unsafe { crate::htslib::bcf_sr_next_line(self.inner) as u32 };
 
             if num == 0 {
-                ensure!(
-                    unsafe { (*self.inner).errnum } == 0,
-                    errors::Error::InvalidRecord
-                );
+                if unsafe { (*self.inner).errnum } != 0 {
+                    return Err(errors::Error::InvalidRecord);
+                }
                 Ok(0)
             } else {
                 assert!(num > 0, "num returned by htslib must not be negative");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,6 @@ extern crate pretty_assertions;
 #[cfg(all(test, feature = "serde"))]
 extern crate serde_json;
 
-extern crate snafu;
-
 pub mod bam;
 pub mod bcf;
 pub mod htslib;

--- a/src/tbx/errors.rs
+++ b/src/tbx/errors.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     #[error("previous iterator generation failed")]
     NoIter,

--- a/src/tbx/errors.rs
+++ b/src/tbx/errors.rs
@@ -1,25 +1,24 @@
-use snafu::Snafu;
 use std::path::PathBuf;
+use thiserror::Error;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-#[derive(Snafu, Debug, PartialEq)]
-#[snafu(visibility = "pub")]
+#[derive(Error, Debug)]
 pub enum Error {
-    #[snafu(display("previous iterator generation failed"))]
+    #[error("previous iterator generation failed")]
     NoIter,
-    #[snafu(display("truncated tabix record"))]
+    #[error("truncated tabix record")]
     TruncatedRecord,
-    #[snafu(display("invalid tabix index"))]
+    #[error("invalid tabix index")]
     InvalidIndex,
-    #[snafu(display("file not found: {}", path.display()))]
+    #[error("file not found: {path}")]
     FileNotFound { path: PathBuf },
-    #[snafu(display("invalid (non-unique) characters in path"))]
+    #[error("invalid (non-unique) characters in path")]
     NonUnicodePath,
-    #[snafu(display("sequence {} not found in tabix index", sequence))]
+    #[error("sequence {sequence} not found in tabix index")]
     UnknownSequence { sequence: String },
-    #[snafu(display("failed to fetch region in tabix index"))]
+    #[error("failed to fetch region in tabix index")]
     Fetch,
-    #[snafu(display("error setting threads for for tabix file reading"))]
+    #[error("error setting threads for for tabix file reading")]
     SetThreads,
 }


### PR DESCRIPTION
This makes the API more ergonomic.

In addition, this PR migrates error handling to thiserror instead of snafu.

Both are breaking changes.