### PR TITLE
bump hts-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_base = { version = "^1", optional = true, package = "serde" }
 serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.6"
 thiserror = "1"
-hts-sys = { version = "^1.10", path = "hts-sys", default-features = false }
+hts-sys = { version = "^1.11", path = "hts-sys", default-features = false }
 
 [features]
 default = ["bzip2", "lzma", "curl"]

--- a/hts-sys/Cargo.toml
+++ b/hts-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hts-sys"
-version = "1.10.2"
+version = "1.11.0"
 authors = ["Christopher Schröder <christopher.schroeder@tu-dortmund.de>", "Johannes Köster <johannes.koester@tu-dortmund.de>"]
 build = "build.rs"
 links = "hts"


### PR DESCRIPTION
fixes #218. The new features we introduced required a new version for hts-sys, otherwise the new version of `rust-htslib` could try and use an older `hts-sys` which doesn't support the features that `rust-htslib` knows about.