### PR TITLE
Use lazy static regex for BAM header parsing

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -14,6 +14,7 @@ use std::str;
 use std::str::FromStr;
 use std::u32;
 
+use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::bam::errors::Result;

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -15,6 +15,7 @@ use std::str;
 
 use bio_types::genome;
 use ieee754::Ieee754;
+use lazy_static::lazy_static;
 
 use crate::bcf::errors::Result;
 use crate::bcf::header::{HeaderView, Id};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,8 +67,6 @@
 
 #[macro_use]
 extern crate custom_derive;
-#[macro_use]
-extern crate lazy_static;
 extern crate libc;
 #[macro_use]
 extern crate newtype_derive;


### PR DESCRIPTION
Compiles the BAM header regex only once by using a lazy static.