### PR TITLE
Add coveralls test coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Crates.io](https://img.shields.io/crates/l/rust-htslib.svg)](https://crates.io/crates/rust-htslib)
 [![docs.rs](https://docs.rs/rust-htslib/badge.svg)](https://docs.rs/rust-htslib)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/rust-bio/rust-htslib/CI/master?label=tests)
+[![Coverage Status](https://coveralls.io/repos/github/rust-bio/rust-htslib/badge.svg?branch=master)](https://coveralls.io/github/rust-bio/rust-htslib?branch=master)
 
 # HTSlib bindings for Rust
 


### PR DESCRIPTION
This should close #82 by adding the test coverage badge to the readme. All other aspects of #82 seem to be addressed by now.