### PR TITLE
Calculate test coverage with all features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--out Lcov --exclude-files hts-sys/*_prebuilt_bindings.rs -- --test-threads 1'
+          args: '--all-features --out Lcov --exclude-files hts-sys/*_prebuilt_bindings.rs -- --test-threads 1'
 
       - name: Upload coverage
         uses: coverallsapp/github-action@master


### PR DESCRIPTION
Includes all features in the calculation of the test coverage. Before, only the default features were used which misses some relevant code parts (e.g. the `serde` feature).