### PR TITLE
Update/lib samtools example

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -832,7 +832,8 @@ fn hts_open(path: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
             unsafe {
                 // Comparison against 'htsFormatCategory_sequence_data' doesn't handle text files correctly
                 // hence the explicit checks against all supported exact formats
-                if (*ret).format.format != htslib::htsExactFormat_bam
+                if (*ret).format.format != htslib::htsExactFormat_sam
+                    && (*ret).format.format != htslib::htsExactFormat_bam
                     && (*ret).format.format != htslib::htsExactFormat_cram
                 {
                     return Err(Error::Open {
@@ -1152,6 +1153,14 @@ CCCCCCCCCCCCCCCCCCC"[..],
             .to_string();
         let header_text = String::from_utf8(bam.header.as_bytes().to_owned()).unwrap();
         assert_eq!(header_text, true_header);
+    }
+
+    #[test]
+    fn test_read_against_sam() {
+        let mut bam = Reader::from_path("./test/bam2sam_out.sam").unwrap();
+        for read in bam.records() {
+            let _read = read.unwrap();
+        }
     }
 
     fn _test_read_indexed_common(mut bam: IndexedReader) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@
 
 //! ```
 //! samtools view -H test/test.bam
-//! @SQ	SN:CHROMOSOME_I	LN:15072423
-//! @SQ	SN:CHROMOSOME_II	LN:15279345
-//! @SQ	SN:CHROMOSOME_III	LN:13783700
-//! @SQ	SN:CHROMOSOME_IV	LN:17493793
-//! @SQ	SN:CHROMOSOME_V	LN:20924149
+//! @SQ    SN:CHROMOSOME_I    LN:15072423
+//! @SQ    SN:CHROMOSOME_II    LN:15279345
+//! @SQ    SN:CHROMOSOME_III    LN:13783700
+//! @SQ    SN:CHROMOSOME_IV    LN:17493793
+//! @SQ    SN:CHROMOSOME_V    LN:20924149
 //! ```
 //!
 //! We can reproduce that with Rust-Htslib. Reading BAM files and printing the header
@@ -41,11 +41,11 @@
 //! which results in the following output, equivalent to samtools.
 //!
 //! ```bash
-//! @SQ	SN:CHROMOSOME_I	LN:15072423
-//! @SQ	SN:CHROMOSOME_II	LN:15279345
-//! @SQ	SN:CHROMOSOME_III	LN:13783700
-//! @SQ	SN:CHROMOSOME_IV	LN:17493793
-//! @SQ	SN:CHROMOSOME_V	LN:20924149
+//! @SQ    SN:CHROMOSOME_I    LN:15072423
+//! @SQ    SN:CHROMOSOME_II    LN:15279345
+//! @SQ    SN:CHROMOSOME_III    LN:13783700
+//! @SQ    SN:CHROMOSOME_IV    LN:17493793
+//! @SQ    SN:CHROMOSOME_V    LN:20924149
 //! ```
 //!
 //! We can also read directly from the BAM file and write to an output file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! HTS alignments (SAM and BAM) as well as variant calls in VCF and BCF format.
 //!
 //! For example, let's say that we use samtools to view the header of a test file:
-
+//!
 //! ```
 //! samtools view -H test/test.bam
 //! @SQ    SN:CHROMOSOME_I    LN:15072423

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,47 @@
 //! Htslib itself is the *de facto* standard implementation for reading and writing files for
 //! HTS alignments (SAM and BAM) as well as variant calls in VCF and BCF format.
 //!
-//! For example, reading and writing BAM files is as easy as
+//! For example, let's say that we use samtools to view the header of a test file:
+
+//! ```
+//! samtools view -H test/test.bam
+//! @SQ	SN:CHROMOSOME_I	LN:15072423
+//! @SQ	SN:CHROMOSOME_II	LN:15279345
+//! @SQ	SN:CHROMOSOME_III	LN:13783700
+//! @SQ	SN:CHROMOSOME_IV	LN:17493793
+//! @SQ	SN:CHROMOSOME_V	LN:20924149
+//! ```
+//!
+//! We can reproduce that with Rust-Htslib. Reading BAM files and printing the header
+//! to the the screen is as easy as
+//!
+//! ```rust
+//! use rust_htslib::{bam, bam::Read};
+//!
+//! fn main() {
+//!     let bam = bam::Reader::from_path(&"data/test.bam").unwrap();
+//!     let header = bam::Header::from_template(bam.header());
+//!
+//!     // print header records to the terminal, akin to samtool
+//!     for (key, records) in header.to_hashmap() {
+//!         for record in records {
+//!             println!("@{}\tSN:{}\tLN:{}", key, record["SN"], record["LN"]);
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! which results in the following output, equivalent to samtools.
+//!
+//! ```bash
+//! @SQ	SN:CHROMOSOME_I	LN:15072423
+//! @SQ	SN:CHROMOSOME_II	LN:15279345
+//! @SQ	SN:CHROMOSOME_III	LN:13783700
+//! @SQ	SN:CHROMOSOME_IV	LN:17493793
+//! @SQ	SN:CHROMOSOME_V	LN:20924149
+//! ```
+//!
+//! We can also read directly from the BAM file and write to an output file
 //!
 //! ```
 //! use rust_htslib::{bam, bam::Read};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! For example, let's say that we use samtools to view the header of a test file:
 //!
-//! ```
+//! ```bash
 //! samtools view -H test/test.bam
 //! @SQ    SN:CHROMOSOME_I    LN:15072423
 //! @SQ    SN:CHROMOSOME_II    LN:15279345
@@ -22,11 +22,11 @@
 //! We can reproduce that with Rust-Htslib. Reading BAM files and printing the header
 //! to the the screen is as easy as
 //!
-//! ```rust
+//! ```
 //! use rust_htslib::{bam, bam::Read};
 //!
 //! fn main() {
-//!     let bam = bam::Reader::from_path(&"data/test.bam").unwrap();
+//!     let bam = bam::Reader::from_path(&"test/test.bam").unwrap();
 //!     let header = bam::Header::from_template(bam.header());
 //!
 //!     // print header records to the terminal, akin to samtool


### PR DESCRIPTION
It took me a while to figure out where exactly the docs are, and how they are generated, but finally I did! This is a small PR that adds an example to generate the same output with rust-htslib as you would with samtools to inspect a header (discussed in https://github.com/rust-bio/rust-htslib/issues/244#issuecomment-684108611). I'll also add some notes to give perspective from a relatively new user exploring the library.

## Setup
If you are a seasoned rustacean, it's obvious that you'd have a project, and know how to interact with cargo. if you are a bioscientist coming to the repository and not familiar with rust, it's a little bit more challenging to get started. I realized that in order to even test small snippets of code, I'd need to install rust-htslib (documentation I found in the README, and I was caught up a bit by not doing the `--recursive` clone to get the entire thing) and then figuring out how to create a sample project, e.g.,

```bash
$ tree rust-htslib-example/ -L 1
rust-htslib-example/
├── Cargo.lock
├── Cargo.toml
├── data
├── README.md
├── src
└── target

3 directories, 3 files
```
This gave me enough to be able to copy snippets from the docs, and try things out. I also installed samtools with conda. I suspect that a very new user would not just be provided these docs (which are for specific functions and source code) but would have a tutorial to walk them through the entire process? I'm curious about the intended audience for the documentation, and how new folks will be gently introduced.

## Looking at the header / bam classes
Are these called classes? Structures (or I see Struct)? Something else? I knew that my goal was to reproduce the samtools output but with rust-htslib - a user familiar with samtools would appreciate seeing this from the getgo. I first tried looking at the current code to loop through the records of the bam (not the header):

```rust
use rust_htslib::{bam, bam::Read};

fn main() {

    let mut bam = bam::Reader::from_path(&"data/test.bam").unwrap();
    let header = bam::Header::from_template(bam.header());

    // copy reverse reads to new BAM file
    for r in bam.records() {
        let record = r.unwrap();
        if record.is_reverse() {
            println!("{:?}", &record.inner);
        }
    }
}
```
That prints out quite a bit, and although it could be that something could be mapped from there to the samtools output, I suspect not - this is likely records in the bam file, and not the header

```bash
    Finished dev [unoptimized + debuginfo] target(s) in 1.21s
     Running `target/debug/rust-htslib-example`
bam1_t { core: bam1_core_t { pos: 1, tid: 0, bin: 4681, qual: 1, l_extranul: 2, flag: 16, l_qname: 4, n_cigar: 3, l_qseq: 100, mtid: -1, mpos: -1, isize: 0 }, id: 0, data: 0x55bb6db58010, l_data: 196, m_data: 256, _bitfield_1: __BindgenBitfieldUnit { storage: [0, 0, 0, 0], align: [] }, __bindgen_padding_0: 0 }
bam1_t { core: bam1_core_t { pos: 1, tid: 0, bin: 4681, qual: 1, l_extranul: 0, flag: 16, l_qname: 12, n_cigar: 3, l_qseq: 100, mtid: -1, mpos: -1, isize: 0 }, id: 0, data: 0x55bb6db58010, l_data: 204, m_data: 256, _bitfield_1: __BindgenBitfieldUnit { storage: [0, 0, 0, 0], align: [] }, __bindgen_padding_0: 0 }
bam1_t { core: bam1_core_t { pos: 1, tid: 0, bin: 4681, qual: 1, l_extranul: 0, flag: 16, l_qname: 4, n_cigar: 3, l_qseq: 100, mtid: -1, mpos: -1, isize: 0 }, id: 0, data: 0x55bb6db58010, l_data: 196, m_data: 256, _bitfield_1: __BindgenBitfieldUnit { storage: [0, 0, 0, 0], align: [] }, __bindgen_padding_0: 0 }
bam1_t { core: bam1_core_t { pos: 1, tid: 0, bin: 4681, qual: 40, l_extranul: 1, flag: 16, l_qname: 4, n_cigar: 3, l_qseq: 100, mtid: -1, mpos: -1, isize: 0 }, id: 0, data: 0x55bb6db58010, l_data: 196, m_data: 256, _bitfield_1: __BindgenBitfieldUnit { storage: [0, 0, 0, 0], align: [] }, __bindgen_padding_0: 0 }
bam1_t { core: bam1_core_t { pos: 1, tid: 0, bin: 4681, qual: 1, l_extranul: 2, flag: 16, l_qname: 4, n_cigar: 3, l_qseq: 100, mtid: -1, mpos: -1, isize: 0 }, id: 0, data: 0x55bb6db58010, l_data: 196, m_data: 256, _bitfield_1: __BindgenBitfieldUnit { storage: [0, 0, 0, 0], align: [] }, __bindgen_padding_0: 0 }
```

I decided this isn't what I want, and explored the header instead. First I just printed it.

```rust
fn main() {

    let mut bam = bam::Reader::from_path(&"data/test.bam").unwrap();
    let header = bam::Header::from_template(bam.header());

    println!("{:?}", header)
}
```
 I see a list of records.

```
    Finished dev [unoptimized + debuginfo] target(s) in 1.18s
     Running `target/debug/rust-htslib-example`
Header { records: [[64, 83, 81, 9, 83, 78, 58, 67, 72, 82, 79, 77, 79, 83, 79, 77, 69, 95, 73, 9, 76, 78, 58, 49, 53, 48, 55, 50, 52, 50, 51, 10, 64, 83, 81, 9, 83, 78, 58, 67, 72, 82, 79, 77, 79, 83, 79, 77, 69, 95, 73, 73, 9, 76, 78, 58, 49, 53, 50, 55, 57, 51, 52, 53, 10, 64, 83, 81, 9, 83, 78, 58, 67, 72, 82, 79, 77, 79, 83, 79, 77, 69, 95, 73, 73, 73, 9, 76, 78, 58, 49, 51, 55, 56, 51, 55, 48, 48, 10, 64, 83, 81, 9, 83, 78, 58, 67, 72, 82, 79, 77, 79, 83, 79, 77, 69, 95, 73, 86, 9, 76, 78, 58, 49, 55, 52, 57, 51, 55, 57, 51, 10, 64, 83, 81, 9, 83, 78, 58, 67, 72, 82, 79, 77, 79, 83, 79, 77, 69, 95, 86, 9, 76, 78, 58, 50, 48, 57, 50, 52, 49, 52, 57]] }
```

As a new user, what I next do is look at the source code to see what public functions are available. I found the function `to_hashmap`:

```rust
use rust_htslib::{bam, bam::Read};

fn main() {

    let mut bam = bam::Reader::from_path(&"data/test.bam").unwrap();
    let header = bam::Header::from_template(bam.header());

    println!("{:?}", header.to_hashmap());

}
```
which looks promising! It mirrors what is found in the samtools output: 

```
warning: 1 warning emitted

    Finished dev [unoptimized + debuginfo] target(s) in 1.41s
     Running `target/debug/rust-htslib-example`
{"SQ": [{"SN": "CHROMOSOME_I", "LN": "15072423"}, {"SN": "CHROMOSOME_II", "LN": "15279345"}, {"SN": "CHROMOSOME_III", "LN": "13783700"}, {"SN": "CHROMOSOME_IV", "LN": "17493793"}, {"SN": "CHROMOSOME_V", "LN": "20924149"}]}
```
Then it came down to realizing that the hashmap above has one key (SQ) which is a list of other maps, and I just needed to format the print to be the same as samtools (with an @ and then tab delimited).

```
@SQ	SN:CHROMOSOME_I	LN:15072423
@SQ	SN:CHROMOSOME_II	LN:15279345
@SQ	SN:CHROMOSOME_III	LN:13783700
@SQ	SN:CHROMOSOME_IV	LN:17493793
@SQ	SN:CHROMOSOME_V	LN:20924149
```
And that's the PR here! Very simple, and hopefully the walkthrough above can shed insight for what might be important for a user (I suspect the main developers here are experts with rust and forget what it's like to be a new person). I left the other examples as is. I can definitely act as tester / documentation updater for other snippets if someone wants to point them out.

I had started other work (for the previous issue) and wound up not using the branch, hence the commits seen here. Is it okay with the maintainers here to do a squash and merge to clean up the commit history, or should I be more careful in the future and do rebase?