### PR TITLE
Introduced BamRecordExtensions::aligned_block_pairs

### DIFF
--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -48,7 +48,6 @@ impl Iterator for IterAlignedBlockPairs {
     }
 }
 
-
 pub struct IterAlignedBlocks {
     pos: i64,
     cigar_index: usize,
@@ -330,15 +329,15 @@ impl BamRecordExtensions for bam::Record {
             cigar_index: 0,
         }
     }
-    
+
     fn aligned_block_pairs(&self) -> IterAlignedBlockPairs {
-        IterAlignedBlockPairs{
+        IterAlignedBlockPairs {
             genome_pos: self.pos(),
             read_pos: 0,
             cigar: self.cigar().take().0,
             cigar_index: 0,
         }
-   }
+    }
 
     fn aligned_pairs(&self) -> IterAlignedPairs {
         IterAlignedPairs {


### PR DESCRIPTION
You could get read&genome coordinates base-by-base,
or you could get genome-coordinates in continuously aligned blocks,
but you couldn't get read&genome coordinates in blocks.

Since I recently ran into a situtation where not allocating every position just to iterate through them shaved of a few percentages of my runtime, 
I thought I might as well contribute the combined function.