### PR TITLE
Applying 'cargo audit' results

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ static = ["hts-sys/static"]
 serde_feature = ["serde", "serde_bytes"]
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3.1.0"
 bincode = "1.2"
 serde_json = "1.0"
 pretty_assertions = "0.6"

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1397,7 +1397,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
         {
@@ -1443,7 +1443,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write_threaded() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
         {
@@ -1494,7 +1494,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write_shared_tpool() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bampath1 = tmp.path().join("test1.bam");
         let bampath2 = tmp.path().join("test2.bam");
 
@@ -1571,7 +1571,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         // Verify that BAM headers are transmitted correctly when using an existing BAM as a
         // template for headers.
 
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
 
@@ -1715,7 +1715,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let bam_records: Vec<Record> = bam_reader.records().map(|v| v.unwrap()).collect();
 
         // New CRAM file
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let cram_path = tmp.path().join("test.cram");
 
         // Write BAM records to new CRAM file
@@ -1791,7 +1791,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_write_compression() {
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let input_bam_path = "test/test.bam";
 
         // test levels with decreasing compression factor

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1397,7 +1397,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
         {
@@ -1443,7 +1446,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write_threaded() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
         {
@@ -1494,7 +1500,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_write_shared_tpool() {
         let (names, _, seqs, quals, cigars) = gold();
 
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bampath1 = tmp.path().join("test1.bam");
         let bampath2 = tmp.path().join("test2.bam");
 
@@ -1571,7 +1580,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
         // Verify that BAM headers are transmitted correctly when using an existing BAM as a
         // template for headers.
 
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
 
@@ -1715,7 +1727,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let bam_records: Vec<Record> = bam_reader.records().map(|v| v.unwrap()).collect();
 
         // New CRAM file
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let cram_path = tmp.path().join("test.cram");
 
         // Write BAM records to new CRAM file
@@ -1791,7 +1806,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_write_compression() {
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let input_bam_path = "test/test.bam";
 
         // test levels with decreasing compression factor

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -800,7 +800,10 @@ mod tests {
     #[test]
     fn test_writer_set_threads() {
         let path = &"test/test.bcf";
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bcfpath = tmp.path().join("test.bcf");
         let bcf = Reader::from_path(path).expect("Error opening file.");
         let header = Header::from_template_subset(&bcf.header, &[b"NA12878.subsample-0.25-0"])
@@ -825,7 +828,10 @@ mod tests {
     #[test]
     fn test_write() {
         let mut bcf = Reader::from_path(&"test/test_multi.bcf").expect("Error opening file.");
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let bcfpath = tmp.path().join("test.bcf");
         println!("{:?}", bcfpath);
         {
@@ -1101,7 +1107,10 @@ mod tests {
     #[test]
     fn test_write_various() {
         // Open reader, then create writer.
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let out_path = tmp.path().join("test_various.out.vcf");
 
         let vcf = Reader::from_path(&"test/test_various.vcf").expect("Error opening file.");
@@ -1175,7 +1184,10 @@ mod tests {
     #[test]
     fn test_remove_headers() {
         let vcf = Reader::from_path(&"test/test_headers.vcf").expect("Error opening file.");
-        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new()
+            .prefix("rust-htslib")
+            .tempdir()
+            .expect("Cannot create temp dir");
         let vcfpath = tmp.path().join("test.vcf");
         let mut header = Header::from_template(&vcf.header);
         header

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -800,7 +800,7 @@ mod tests {
     #[test]
     fn test_writer_set_threads() {
         let path = &"test/test.bcf";
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bcfpath = tmp.path().join("test.bcf");
         let bcf = Reader::from_path(path).expect("Error opening file.");
         let header = Header::from_template_subset(&bcf.header, &[b"NA12878.subsample-0.25-0"])
@@ -825,7 +825,7 @@ mod tests {
     #[test]
     fn test_write() {
         let mut bcf = Reader::from_path(&"test/test_multi.bcf").expect("Error opening file.");
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let bcfpath = tmp.path().join("test.bcf");
         println!("{:?}", bcfpath);
         {
@@ -1101,7 +1101,7 @@ mod tests {
     #[test]
     fn test_write_various() {
         // Open reader, then create writer.
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let out_path = tmp.path().join("test_various.out.vcf");
 
         let vcf = Reader::from_path(&"test/test_various.vcf").expect("Error opening file.");
@@ -1175,7 +1175,7 @@ mod tests {
     #[test]
     fn test_remove_headers() {
         let vcf = Reader::from_path(&"test/test_headers.vcf").expect("Error opening file.");
-        let tmp = tempdir::TempDir::new("rust-htslib").expect("Cannot create temp dir");
+        let tmp = tempfile::Builder::new().prefix("rust-htslib").tempdir().expect("Cannot create temp dir");
         let vcfpath = tmp.path().join("test.vcf");
         let mut header = Header::from_template(&vcf.header);
         header


### PR DESCRIPTION
Cargo audit revealed that we were using a deprecated crate called 'tempdir' for our tests.
This has been replaced with the suggested successor 'tempfile'.

Low hanging fruit, basically.