### PR TITLE
introduce Reader::rc_records

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -98,7 +98,7 @@ pub trait Read: Sized {
     /// use rust_htslib::bam::{Error, Read, IndexedReader, Record};
     ///
     /// let mut bam = IndexedReader::from_path(&"test/test.bam").unwrap();
-    /// bam.fetch(0, 1000, 2000); // reads on tid 0, from 1000bp to 2000bp
+    /// bam.fetch((0, 1000, 2000)); // reads on tid 0, from 1000bp to 2000bp
     /// let mut record = Record::new();
     /// loop {
     ///     match bam.read(&mut record){

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -133,7 +133,6 @@ pub trait Read: Sized {
     /// use rust_htslib::bam::{Error, Read, Reader, Record};
     /// use rust_htslib::htslib; // for BAM_F*
     /// let mut bam = Reader::from_path(&"test/test.bam").unwrap();
-    /// let record = Record::new();
     //
     /// for read in
     ///     bam.rc_records()

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -133,7 +133,7 @@ pub trait Read: Sized {
     /// use rust_htslib::bam::{Error, Read, Reader, Record};
     /// use rust_htslib::htslib; // for BAM_F*
     /// let mut bam = Reader::from_path(&"test/test.bam").unwrap();
-    //
+    ///
     /// for read in
     ///     bam.rc_records()
     ///     .map(|x| x.expect("Failure parsing Bam file"))


### PR DESCRIPTION
This extracts and cleans up the RcRecords from #163. In brief, this is an iterator based API for BAM files that uses an Rc<> to avoid allocations. 

Speed in benchmarks is on par with the `read` based API ( see #163) - in my actual applications I have not been able to see a difference at all whatsoever.

This also introduces a 'sensible error handling' example for the `read` API, since I was working on those doc strings anyway.