### PR TITLE
Explicitly reference std::i64::MAX instead of i64::MAX

### DIFF
--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -75,10 +75,10 @@ impl Reader {
     /// * `begin` - the offset within the template sequence (starting with 0)
     /// * `end` - the end position to return (if smaller than `begin`, the behavior is undefined).
     pub fn fetch_seq<N: AsRef<str>>(&self, name: N, begin: usize, end: usize) -> Result<&[u8]> {
-        if begin > i64::MAX as usize {
+        if begin > std::i64::MAX as usize {
             return Err(Error::PositionTooLarge);
         }
-        if end > i64::MAX as usize {
+        if end > std::i64::MAX as usize {
             return Err(Error::PositionTooLarge);
         }
         let cname = ffi::CString::new(name.as_ref().as_bytes()).unwrap();


### PR DESCRIPTION
Compiling with older versions of rust like v1.41.0 failed because it does not directly resolve i64 into `std`. To reproduce run
```bash
rustup run 1.41.0 cargo build
``` 
which results in error:
```
Compiling rust-htslib v0.32.1-alpha.0 (/data/rust/rust-htslib)
error[E0599]: no associated item named `MAX` found for type `i64` in the current scope
  --> src/faidx/mod.rs:78:25
   |
78 |         if begin > i64::MAX as usize {
   |                         ^^^ associated item not found in `i64`
   |
help: you are looking for the module in `std`, not the primitive type
   |
78 |         if begin > std::i64::MAX as usize {
   |                    ^^^^^^^^^^^^^

error[E0599]: no associated item named `MAX` found for type `i64` in the current scope
  --> src/faidx/mod.rs:81:23
   |
81 |         if end > i64::MAX as usize {
   |                       ^^^ associated item not found in `i64`
   |
help: you are looking for the module in `std`, not the primitive type
   |
81 |         if end > std::i64::MAX as usize {
   |                  ^^^^^^^^^^^^^
