### PR TITLE
fixed clippy warnings

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -36,7 +36,7 @@ use std::convert::TryInto;
 /// # Safety
 ///
 /// Implementation for `Read::set_threads` and `Writer::set_threads`.
-pub unsafe fn set_threads(htsfile: *mut htslib::htsFile, n_threads: usize) -> Result<()> {
+unsafe fn set_threads(htsfile: *mut htslib::htsFile, n_threads: usize) -> Result<()> {
     assert!(n_threads != 0, "n_threads must be > 0");
 
     if htslib::hts_set_threads(htsfile, n_threads as i32) != 0 {
@@ -46,7 +46,7 @@ pub unsafe fn set_threads(htsfile: *mut htslib::htsFile, n_threads: usize) -> Re
     }
 }
 
-pub unsafe fn set_thread_pool(htsfile: *mut htslib::htsFile, tpool: &ThreadPool) -> Result<()> {
+unsafe fn set_thread_pool(htsfile: *mut htslib::htsFile, tpool: &ThreadPool) -> Result<()> {
     let mut b = tpool.handle.borrow_mut();
 
     if htslib::hts_set_thread_pool(htsfile, &mut b.inner as *mut _) != 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,15 +25,14 @@
 //! ```
 //! use rust_htslib::{bam, bam::Read};
 //!
-//! fn main() {
-//!     let bam = bam::Reader::from_path(&"test/test.bam").unwrap();
-//!     let header = bam::Header::from_template(bam.header());
 //!
-//!     // print header records to the terminal, akin to samtool
-//!     for (key, records) in header.to_hashmap() {
-//!         for record in records {
-//!             println!("@{}\tSN:{}\tLN:{}", key, record["SN"], record["LN"]);
-//!         }
+//! let bam = bam::Reader::from_path(&"test/test.bam").unwrap();
+//! let header = bam::Header::from_template(bam.header());
+//!
+//! // print header records to the terminal, akin to samtool
+//! for (key, records) in header.to_hashmap() {
+//!     for record in records {
+//!          println!("@{}\tSN:{}\tLN:{}", key, record["SN"], record["LN"]);
 //!     }
 //! }
 //! ```

--- a/src/tpool.rs
+++ b/src/tpool.rs
@@ -44,7 +44,7 @@ pub struct InnerThreadPool {
 
 impl Drop for InnerThreadPool {
     fn drop(&mut self) {
-        if self.inner.pool != std::ptr::null_mut() {
+        if !self.inner.pool.is_null() {
             unsafe {
                 htslib::hts_tpool_destroy(self.inner.pool);
             }


### PR DESCRIPTION
We had a handful of clippy warnings, now we don't.

This also 'un-pubs' two unsafe functions that are used between Reader classes - not sure why these were public in the first place?