### PR TITLE
Helper to push genotypes to BCF record

### DIFF
--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1161,6 +1161,13 @@ mod tests {
             record.push_info_flag(b"X1").unwrap();
 
             record
+                .push_genotypes(&[GenotypeAllele::Unphased(0),
+                                  GenotypeAllele::Unphased(1),
+                                  GenotypeAllele::Unphased(1),
+                                  GenotypeAllele::Phased(1)]).
+                unwrap();
+
+            record
                 .push_format_string(b"FS1", &[&b"yes"[..], &b"no"[..]])
                 .unwrap();
             record.push_format_integer(b"FF1", &[43, 11]).unwrap();

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1386,6 +1386,7 @@ mod tests {
         let converted: i32 = allele.into();
         let expected = 1;
         assert_eq!(converted, expected);
+    }
 
     #[test]
     fn test_alt_allele_dosage() {

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -729,8 +729,8 @@ fn bcf_open(target: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
 mod tests {
     use super::*;
     use crate::bcf::header::Id;
-    use crate::bcf::record::Numeric;
     use crate::bcf::record::GenotypeAllele;
+    use crate::bcf::record::Numeric;
     use std::fs::File;
     use std::io::prelude::Read as IoRead;
     use std::path::Path;
@@ -1161,11 +1161,13 @@ mod tests {
             record.push_info_flag(b"X1").unwrap();
 
             record
-                .push_genotypes(&[GenotypeAllele::Unphased(0),
-                                  GenotypeAllele::Unphased(1),
-                                  GenotypeAllele::Unphased(1),
-                                  GenotypeAllele::Phased(1)]).
-                unwrap();
+                .push_genotypes(&[
+                    GenotypeAllele::Unphased(0),
+                    GenotypeAllele::Unphased(1),
+                    GenotypeAllele::Unphased(1),
+                    GenotypeAllele::Phased(1),
+                ])
+                .unwrap();
 
             record
                 .push_format_string(b"FS1", &[&b"yes"[..], &b"no"[..]])

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -730,6 +730,7 @@ mod tests {
     use super::*;
     use crate::bcf::header::Id;
     use crate::bcf::record::Numeric;
+    use crate::bcf::record::GenotypeAllele;
     use std::fs::File;
     use std::io::prelude::Read as IoRead;
     use std::path::Path;
@@ -1304,5 +1305,21 @@ mod tests {
         let _ = reader.read(&mut rec);
 
         assert_eq!(rec.info(b"X").string().unwrap().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_genotype_allele_conversion() {
+        let allele = GenotypeAllele::Unphased(1);
+        let converted: i32 = allele.into();
+        let expected = 4;
+        assert_eq!(converted, expected);
+    }
+
+    #[test]
+    fn test_genotype_missing_allele_conversion() {
+        let allele = GenotypeAllele::PhasedMissing;
+        let converted: i32 = allele.into();
+        let expected = 1;
+        assert_eq!(converted, expected);
     }
 }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -365,10 +365,7 @@ impl Record {
     ///
     /// Returns error if GT tag is not present in header.
     pub fn push_genotypes(&mut self, genotypes: &[GenotypeAllele]) -> Result<()> {
-        let encoded: Vec<i32> = genotypes
-            .iter()
-            .map(|gt| i32::from(*gt))
-            .collect();
+        let encoded: Vec<i32> = genotypes.iter().map(|gt| i32::from(*gt)).collect();
         self.push_format_integer("GT".as_bytes(), &encoded)
     }
 

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -674,6 +674,18 @@ impl fmt::Display for GenotypeAllele {
     }
 }
 
+impl From<GenotypeAllele> for i32 {
+    fn from(allele: GenotypeAllele) -> i32 {
+        let (allele, phased) = match allele {
+            GenotypeAllele::UnphasedMissing => (-1, 0),
+            GenotypeAllele::PhasedMissing => (-1, 1),
+            GenotypeAllele::Unphased(a) => (a, 0),
+            GenotypeAllele::Phased(a) => (a, 1),
+        };
+        allele + 1 << 1 | phased
+    }
+}
+
 custom_derive! {
     /// Genotype representation as a vector of `GenotypeAllele`.
     #[derive(NewtypeDeref, Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -354,7 +354,23 @@ impl Record {
         self.inner().n_allele()
     }
 
-    // TODO fn push_genotypes(&mut self, Genotypes) {}?
+    /// Add/replace genotypes in FORMAT GT tag.
+    ///
+    /// # Arguments
+    ///
+    /// - `genotypes` - a flattened, two-dimensional array of GenotypeAllele,
+    ///                 the first dimension contains one array for each sample.
+    ///
+    /// # Errors
+    ///
+    /// Returns error if GT tag is not present in header.
+    pub fn push_genotypes(&mut self, genotypes: &[GenotypeAllele]) -> Result<()> {
+        let encoded: Vec<i32> = genotypes
+            .iter()
+            .map(|gt| i32::from(*gt))
+            .collect();
+        self.push_format_integer("GT".as_bytes(), &encoded)
+    }
 
     /// Get genotypes as vector of one `Genotype` per sample.
     pub fn genotypes(&mut self) -> Result<Genotypes<'_>> {
@@ -438,7 +454,8 @@ impl Record {
 
     // TODO: should we add convenience methods clear_format_*?
 
-    /// Add a string-typed FORMAT tag.
+    /// Add a string-typed FORMAT tag. Note that genotypes are treated as a special case
+    /// and cannot be added with this method. See instead [push_genotypes](#method.push_genotypes).
     ///
     /// # Arguments
     ///

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -366,7 +366,7 @@ impl Record {
     /// Returns error if GT tag is not present in header.
     pub fn push_genotypes(&mut self, genotypes: &[GenotypeAllele]) -> Result<()> {
         let encoded: Vec<i32> = genotypes.iter().map(|gt| i32::from(*gt)).collect();
-        self.push_format_integer("GT".as_bytes(), &encoded)
+        self.push_format_integer(b"GT", &encoded)
     }
 
     /// Get genotypes as vector of one `Genotype` per sample.

--- a/test/test_various.out.vcf
+++ b/test/test_various.out.vcf
@@ -13,4 +13,4 @@
 ##FORMAT=<ID=CH1,Number=1,Type=Character,Description="Single FORMAT char">
 ##contig=<ID=19,length=59128983>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	one	two
-19	13	first_id;second_id	C	T,G	10	s50;q10	N1=32;F1=33;S1=fourtytwo;X1	FS1:FF1:FN1:CH1	yes:43:42:A	no:11:10:B
+19	13	first_id;second_id	C	T,G	10	s50;q10	N1=32;F1=33;S1=fourtytwo;X1	GT:FS1:FF1:FN1:CH1	0/1:yes:43:42:A	1|1:no:11:10:B


### PR DESCRIPTION
With reference to [#224 ](https://github.com/rust-bio/rust-htslib/issues/224), pull request includes:

1. Write `impl From<GenotypeAllele> for i32 {}` to encode `GenotypeAllele`s according to BCF specs.
2. Write `push_genotypes` helper for Record to add an array of `GenotypeAllele`s to `Record`, which is a simple wrapper around `GenotypeAllele` conversion and `push_format_integer`.

I've also added a bit of testing for both. I also mean to try and improve the documentation for pushing information onto records (as mentioned in the issue), but I thought to keep that in a later pull request once this is settled.

I'm still getting used to Rust and pull requests; feedback very welcome.