### PR TITLE
Separate buffer handling for info and format access.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ serde_bytes = { version = "0.11", optional = true }
 bio-types = ">=0.6"
 thiserror = "1"
 hts-sys = { version = "1.11.0", path = "hts-sys", default-features = false }
+derefable = "0.1"
+derive-new = "0.5"
 
 [features]
 default = ["bzip2", "lzma", "curl"]

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1343,7 +1343,7 @@ mod tests {
         let mut record = reader.empty_record();
         reader.read(&mut record).unwrap().unwrap();
 
-        assert_eq!(record.info(b"SVLEN").integer().unwrap(), Some(&[-127][..]));
+        assert_eq!(*record.info(b"SVLEN").integer().unwrap().unwrap(), &[-127][..]);
     }
 
     #[test]
@@ -1434,5 +1434,14 @@ mod tests {
         assert_eq!(n_ref, [0, 0]);
         assert_eq!(n_alt, [1, 2]);
         assert_eq!(n_missing, [1, 0]);
+    }
+
+    #[test]
+    fn test_obs_cornercase() {
+        let mut reader = Reader::from_path("test/obs-cornercase.vcf").unwrap();
+        let mut first_record = reader.records().next().unwrap().expect("Fail to read record");
+
+        assert_eq!(*first_record.info(b"EVENT").string().unwrap().unwrap(), [b"gridss33fb_1085"]);
+        assert_eq!(*first_record.info(b"MATEID").string().unwrap().unwrap(), [b"gridss33fb_1085h"]);
     }
 }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1343,7 +1343,10 @@ mod tests {
         let mut record = reader.empty_record();
         reader.read(&mut record).unwrap().unwrap();
 
-        assert_eq!(*record.info(b"SVLEN").integer().unwrap().unwrap(), &[-127][..]);
+        assert_eq!(
+            *record.info(b"SVLEN").integer().unwrap().unwrap(),
+            &[-127][..]
+        );
     }
 
     #[test]
@@ -1439,9 +1442,19 @@ mod tests {
     #[test]
     fn test_obs_cornercase() {
         let mut reader = Reader::from_path("test/obs-cornercase.vcf").unwrap();
-        let mut first_record = reader.records().next().unwrap().expect("Fail to read record");
+        let mut first_record = reader
+            .records()
+            .next()
+            .unwrap()
+            .expect("Fail to read record");
 
-        assert_eq!(*first_record.info(b"EVENT").string().unwrap().unwrap(), [b"gridss33fb_1085"]);
-        assert_eq!(*first_record.info(b"MATEID").string().unwrap().unwrap(), [b"gridss33fb_1085h"]);
+        assert_eq!(
+            *first_record.info(b"EVENT").string().unwrap().unwrap(),
+            [b"gridss33fb_1085"]
+        );
+        assert_eq!(
+            *first_record.info(b"MATEID").string().unwrap().unwrap(),
+            [b"gridss33fb_1085h"]
+        );
     }
 }

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -783,6 +783,7 @@ fn bcf_open(target: &[u8], mode: &[u8]) -> Result<*mut htslib::htsFile> {
 mod tests {
     use super::*;
     use crate::bcf::header::Id;
+    use crate::bcf::record::GenotypeAllele;
     use crate::bcf::record::Numeric;
     use crate::bcf::Reader;
     use std::convert::TryFrom;
@@ -1216,6 +1217,15 @@ mod tests {
             record.push_info_flag(b"X1").unwrap();
 
             record
+                .push_genotypes(&[
+                    GenotypeAllele::Unphased(0),
+                    GenotypeAllele::Unphased(1),
+                    GenotypeAllele::Unphased(1),
+                    GenotypeAllele::Phased(1),
+                ])
+                .unwrap();
+
+            record
                 .push_format_string(b"FS1", &[&b"yes"[..], &b"no"[..]])
                 .unwrap();
             record.push_format_integer(b"FF1", &[43, 11]).unwrap();
@@ -1360,6 +1370,22 @@ mod tests {
         let _ = reader.read(&mut rec);
 
         assert_eq!(rec.info(b"X").string().unwrap().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn test_genotype_allele_conversion() {
+        let allele = GenotypeAllele::Unphased(1);
+        let converted: i32 = allele.into();
+        let expected = 4;
+        assert_eq!(converted, expected);
+    }
+
+    #[test]
+    fn test_genotype_missing_allele_conversion() {
+        let allele = GenotypeAllele::PhasedMissing;
+        let converted: i32 = allele.into();
+        let expected = 1;
+        assert_eq!(converted, expected);
     }
 
     #[test]

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -798,7 +798,7 @@ mod tests {
         assert_eq!(bcf.header.samples(), [b"NA12878.subsample-0.25-0"]);
 
         for (i, rec) in bcf.records().enumerate() {
-            let mut record = rec.expect("Error reading record.");
+            let record = rec.expect("Error reading record.");
             assert_eq!(record.sample_count(), 1);
 
             assert_eq!(record.rid().expect("Error reading rid."), 0);
@@ -1442,7 +1442,7 @@ mod tests {
     #[test]
     fn test_obs_cornercase() {
         let mut reader = Reader::from_path("test/obs-cornercase.vcf").unwrap();
-        let mut first_record = reader
+        let first_record = reader
             .records()
             .next()
             .unwrap()
@@ -1457,4 +1457,24 @@ mod tests {
             [b"gridss33fb_1085h"]
         );
     }
+
+    // #[test]
+    // fn test_buffer_lifetime() {
+    //     let mut reader = Reader::from_path("test/obs-cornercase.vcf").unwrap();
+    //     let first_record = reader
+    //         .records()
+    //         .next()
+    //         .unwrap()
+    //         .expect("Fail to read record");
+
+    //     fn get_value<'a, 'b>(record: &'a Record) -> &'b [u8] {
+    //         // FIXME: this should not be possible, because the slice outlives the buffer.
+    //         let buffer: BufferBacked<'b, _, _> = record.info(b"EVENT").string().unwrap().unwrap();
+    //         let value: &'b [u8] = buffer[0];
+    //         value
+    //     }
+
+    //     let buffered = first_record.info(b"EVENT").string().unwrap().unwrap();
+    //     assert_eq!(get_value(&first_record), buffered[0]);
+    // }
 }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -773,7 +773,7 @@ pub struct Info<'a> {
     buffer_len: i32,
 }
 
-impl Drop for Info {
+impl<'a> Drop for Info<'a> {
     fn drop(&mut self) {
         unsafe { ::libc::free(self.buffer as *mut ::libc::c_void); }
     }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -773,6 +773,12 @@ pub struct Info<'a> {
     buffer_len: i32,
 }
 
+impl Drop for Info {
+    fn drop(&mut self) {
+        unsafe { ::libc::free(self.buffer as *mut ::libc::c_void); }
+    }
+}
+
 impl<'a> Info<'a> {
     /// Short description of info tag.
     pub fn desc(&self) -> String {

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -4,12 +4,12 @@
 // except according to those terms.
 
 use std::borrow::{Borrow, BorrowMut};
-use std::ops::Deref;
-use std::marker::PhantomData;
 use std::f32;
 use std::ffi;
 use std::fmt;
 use std::i32;
+use std::marker::PhantomData;
+use std::ops::Deref;
 use std::ptr;
 use std::rc::Rc;
 use std::slice;
@@ -115,7 +115,9 @@ impl<'a, T: 'a + fmt::Debug, B: Borrow<Buffer> + 'a> Deref for BufferBacked<'a, 
     }
 }
 
-impl<'a, T: 'a + fmt::Debug + fmt::Display, B: Borrow<Buffer> + 'a> fmt::Display for BufferBacked<'a, T, B> {
+impl<'a, T: 'a + fmt::Debug + fmt::Display, B: Borrow<Buffer> + 'a> fmt::Display
+    for BufferBacked<'a, T, B>
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.value, f)
     }
@@ -914,7 +916,7 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Info<'a, 'b, B> {
                             .expect("Bug: returned string should not be empty.")
                     })
                     .collect(),
-                    self.buffer
+                    self.buffer,
                 )
             })
         })

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -767,7 +767,7 @@ unsafe impl Sync for Record {}
 /// Info tag representation.
 #[derive(Debug)]
 pub struct Info<'a> {
-    record: &'a mut Record,
+    record: &'a Record,
     tag: &'a [u8],
     buffer: *mut ::std::os::raw::c_void,
     buffer_len: i32,

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -341,7 +341,7 @@ impl Record {
 
     /// Get the value of the given info tag.
     pub fn info<'a>(&'a mut self, tag: &'a [u8]) -> Info<'_> {
-        Info { record: self, tag }
+        Info { record: self, tag, buffer: ptr::null_mut(), buffer_len: 0 }
     }
 
     /// Get the number of samples.

--- a/test/obs-cornercase.vcf
+++ b/test/obs-cornercase.vcf
@@ -1,0 +1,23 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=SVLEN,Number=A,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=END,Number=A,Type=Integer,Description="End position of structural variant (inclusive, 1-based).">
+##INFO=<ID=SVTYPE,Number=A,Type=String,Description="Structural variant type">
+##INFO=<ID=EVENT,Number=A,Type=String,Description="ID of event associated to breakend">
+##INFO=<ID=MATEID,Number=1,Type=String,Description="ID of mate breakend">
+##contig=<ID=10,length=2601>
+##INFO=<ID=PROB_MAPPING,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=PROB_ALT,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=PROB_REF,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=PROB_MISSED_ALLELE,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=PROB_SAMPLE_ALT,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=PROB_DOUBLE_OVERLAP,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=STRAND,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=READ_ORIENTATION,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##INFO=<ID=SOFTCLIPPED,Number=.,Type=Integer,Description="Varlociraptor observations (binary encoded, meant for internal use only).">
+##varlociraptor_preprocess_args={"Preprocess":{"kind":{"Variants":{"reference":"ref.fa","candidates":"candidates.vcf","bam":"patient13.bam","reference_buffer_size":10,"min_bam_refetch_distance":1,"alignment_properties":null,"output":"patient13.obs.bcf","spurious_ins_rate":2.8e-6,"spurious_del_rate":5.1e-6,"spurious_insext_rate":0.0,"spurious_delext_rate":0.0,"protocol_strandedness":"Opposite","realignment_window":64,"max_depth":200,"omit_insert_size":false,"pairhmm_mode":"exact"}}}}
+##varlociraptor_observation_format_version=5
+##bcftools_viewVersion=1.11+htslib-1.11
+##bcftools_viewCommand=view patient13.obs.bcf; Date=Tue Nov 17 13:48:51 2020
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+10	1301	gridss33fb_1085o	T	T[10:2000[	2.1391e+09	.	EVENT=gridss33fb_1085;SVTYPE=BND;MATEID=gridss33fb_1085h;PROB_MAPPING=2,0,0,0,1,0,6982,48788,1,0,3556,48946;PROB_REF=2,0,0,0,1,0,29208,48945,1,0,29208,48945;PROB_ALT=2,0,0,0,0,0,53400,0,0,53537;PROB_MISSED_ALLELE=2,0,0,0,1,0,29208,49073,1,0,29208,49073;PROB_SAMPLE_ALT=2,0,0,0,1,0,64758,48272,1,0,64758,48272;PROB_DOUBLE_OVERLAP=2,0,0,0,0,0,64512,0,0,64512;STRAND=2,0,0,0,0,0,1,0;READ_ORIENTATION=2,0,0,0,0,0,0,0;SOFTCLIPPED=257,0,0,0,768,2,0,0,0

--- a/test/test_various.out.vcf
+++ b/test/test_various.out.vcf
@@ -13,4 +13,4 @@
 ##FORMAT=<ID=CH1,Number=1,Type=Character,Description="Single FORMAT char">
 ##contig=<ID=19,length=59128983>
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	one	two
-19	13	first_id;second_id	C	T,G	10	s50;q10	N1=32;F1=33;S1=fourtytwo;X1	FS1:FF1:FN1:CH1	yes:43:42:A	no:11:10:B
+19	13	first_id;second_id	C	T,G	10	s50;q10	N1=32;F1=33;S1=fourtytwo;X1	GT:FS1:FF1:FN1:CH1	0/1:yes:43:42:A	1|1:no:11:10:B


### PR DESCRIPTION
Previously, we had one buffer for all. We discovered that this could lead to memory issues, and also race conditions in certain cases. Now, each call to info() and format() will allocate its own buffer. Alternatively it is possible to pass a shared buffer via info_shared_buffer() and format_shared_buffer().