### PR TITLE
Fix bcf missing values and vector end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1"
 hts-sys = { version = "1.11.0", path = "hts-sys", default-features = false }
 derefable = "0.1"
 derive-new = "0.5"
+ieee754 = "0.2"
 
 [features]
 default = ["bzip2", "lzma", "curl"]

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -1121,3 +1121,20 @@ impl<'a> Iterator for Filters<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_float() {
+        let expected: u32 = 0x7F80_0001;
+        assert_eq!(MISSING_FLOAT.bits(), expected);
+    }
+
+    #[test]
+    fn test_vector_end_float() {
+        let expected: u32 = 0x7F80_0002;
+        assert_eq!(VECTOR_END_FLOAT.bits(), expected);
+    }
+}

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -17,6 +17,8 @@ use std::str;
 
 use bio_types::genome;
 use derive_new::new;
+use ieee754::Ieee754;
+use lazy_static::lazy_static;
 
 use crate::bcf::header::{HeaderView, Id};
 use crate::bcf::Error;
@@ -26,8 +28,10 @@ use crate::htslib;
 const MISSING_INTEGER: i32 = i32::MIN;
 const VECTOR_END_INTEGER: i32 = i32::MIN + 1;
 
-const MISSING_FLOAT: u32 = 0x7F80_0001;
-const VECTOR_END_FLOAT: u32 = 0x7F80_0002;
+lazy_static! {
+    static ref MISSING_FLOAT: f32 = Ieee754::from_bits(0x7F80_0001);
+    static ref VECTOR_END_FLOAT: f32 = Ieee754::from_bits(0x7F80_0002);
+}
 
 /// Common methods for numeric INFO and FORMAT entries
 pub trait Numeric {
@@ -40,11 +44,11 @@ pub trait Numeric {
 
 impl Numeric for f32 {
     fn is_missing(&self) -> bool {
-        self.to_bits() == MISSING_FLOAT
+        self.bits() == MISSING_FLOAT.bits()
     }
 
     fn missing() -> f32 {
-        MISSING_FLOAT as f32
+        *MISSING_FLOAT
     }
 }
 
@@ -65,7 +69,7 @@ trait NumericUtils {
 
 impl NumericUtils for f32 {
     fn is_vector_end(&self) -> bool {
-        self.to_bits() == VECTOR_END_FLOAT
+        self.bits() == VECTOR_END_FLOAT.bits()
     }
 }
 


### PR DESCRIPTION
reverts PR #236 which introduced a bug, and adds test cases to avoid this in the future.