### PR TITLE
GenotypeAllele encoding and documentation for pushing to Record

### DIFF
--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -878,7 +878,7 @@ mod tests {
             // the artificial "not observed" allele is present in each record.
             assert_eq!(record.alleles().iter().last().unwrap(), b"<X>");
 
-            let mut fmt = record.format(b"PL");
+            let fmt = record.format(b"PL");
             let pl = fmt.integer().expect("Error reading format.");
             assert_eq!(pl.len(), 1);
             if i == 59 {
@@ -971,7 +971,7 @@ mod tests {
         let mut buffer = Buffer::new();
         for (i, rec) in vcf.records().enumerate() {
             println!("record {}", i);
-            let mut record = rec.expect("Error reading record.");
+            let record = rec.expect("Error reading record.");
             assert_eq!(
                 record
                     .info_shared_buffer(b"S1", &mut buffer)
@@ -1014,7 +1014,7 @@ mod tests {
         let f1 = [false, true];
         let mut buffer = Buffer::new();
         for (i, rec) in vcf.records().enumerate() {
-            let mut record = rec.expect("Error reading record.");
+            let record = rec.expect("Error reading record.");
             assert_eq!(
                 record
                     .info_shared_buffer(b"F1", &mut buffer)
@@ -1044,7 +1044,7 @@ mod tests {
         let mut vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
         let expected = ["./1", "1|1", "0/1", "0|1", "1|.", "1/1"];
         for (rec, exp_gt) in vcf.records().zip(expected.iter()) {
-            let mut rec = rec.expect("Error reading record.");
+            let rec = rec.expect("Error reading record.");
             let genotypes = rec.genotypes().expect("Error reading genotypes");
             assert_eq!(&format!("{}", genotypes.get(0)), exp_gt);
         }
@@ -1468,7 +1468,7 @@ mod tests {
         let _header = bcf.header();
         // FORMAT fields of first record of the vcf should look like:
         // GT:FS1:FN1	./1:LongString1:1	1/1:ss1:2
-        let mut first_record = bcf.records().next().unwrap().expect("Fail to read record");
+        let first_record = bcf.records().next().unwrap().expect("Fail to read record");
         let sample_count = usize::try_from(first_record.sample_count()).unwrap();
         assert_eq!(sample_count, 2);
         let mut n_ref = vec![0; sample_count];

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1399,6 +1399,8 @@ mod tests {
         let converted: i32 = allele.into();
         let expected = 4;
         assert_eq!(converted, expected);
+        let reverse_conversion = GenotypeAllele::from(expected);
+        assert_eq!(allele, reverse_conversion);
     }
 
     #[test]
@@ -1407,6 +1409,8 @@ mod tests {
         let converted: i32 = allele.into();
         let expected = 1;
         assert_eq!(converted, expected);
+        let reverse_conversion = GenotypeAllele::from(expected);
+        assert_eq!(allele, reverse_conversion);
     }
 
     #[test]

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -184,7 +184,8 @@ impl Record {
 
     /// Get the reference id of the record.
     ///
-    /// To look up the contig name, use `bcf::header::HeaderView::rid2name`.
+    /// To look up the contig name,
+    /// use [HeaderView::rid2name](../header/struct.HeaderView.html#method.rid2name).
     ///
     /// # Returns
     ///
@@ -197,7 +198,31 @@ impl Record {
         }
     }
 
-    // Update the internal reference ID number.
+    /// Update the reference id of the record.
+    ///
+    /// To look up reference id for a contig name,
+    /// use [HeaderView::name2rid](../header/struct.HeaderView.html#method.name2rid).
+    ///
+    /// # Example
+    ///
+    /// Example assumes we have a Record `record` from a VCF with a header containing region named `1`.
+    /// See module documentation for how to set up VCF, header, and record.
+    ///
+    /// ```
+    /// # use rust_htslib::bcf::{Format, Writer};
+    /// # use rust_htslib::bcf::header::Header;
+    /// # let mut header = Header::new();
+    /// # let header_contig_line = r#"##contig=<ID=1,length=10>"#;
+    /// # header.push_record(header_contig_line.as_bytes());
+    /// # header.push_sample("test_sample".as_bytes());
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut record = vcf.empty_record();
+    /// let rid = record.header().name2rid(b"1").ok();
+    /// record.set_rid(rid);
+    /// assert_eq!(record.rid(), rid);
+    /// let name = record.header().rid2name(record.rid().unwrap()).ok();
+    /// assert_eq!(Some("1".as_bytes()), name);
+    /// ```
     pub fn set_rid(&mut self, rid: Option<u32>) {
         match rid {
             Some(rid) => self.inner_mut().rid = rid as i32,
@@ -424,6 +449,28 @@ impl Record {
     /// # Errors
     ///
     /// Returns error if GT tag is not present in header.
+    ///
+    /// # Example
+    ///
+    /// Example assumes we have a Record `record` from a VCF with a `GT` `FORMAT` tag.
+    /// See module documentation for how to set up VCF, header, and record.
+    ///
+    /// ```
+    /// # use rust_htslib::bcf::{Format, Writer};
+    /// # use rust_htslib::bcf::header::Header;
+    /// # use rust_htslib::bcf::record::GenotypeAllele;
+    /// # let mut header = Header::new();
+    /// # let header_contig_line = r#"##contig=<ID=1,length=10>"#;
+    /// # header.push_record(header_contig_line.as_bytes());
+    /// # let header_gt_line = r#"##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">"#;
+    /// # header.push_record(header_gt_line.as_bytes());
+    /// # header.push_sample("test_sample".as_bytes());
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut record = vcf.empty_record();
+    /// let alleles = &[GenotypeAllele::Unphased(1), GenotypeAllele::Unphased(1)];
+    /// record.push_genotypes(alleles);
+    /// assert_eq!("1/1", &format!("{}", record.genotypes().unwrap().get(0)));
+    /// ```
     pub fn push_genotypes(&mut self, genotypes: &[GenotypeAllele]) -> Result<()> {
         let encoded: Vec<i32> = genotypes.iter().map(|gt| i32::from(*gt)).collect();
         self.push_format_integer(b"GT", &encoded)
@@ -494,6 +541,27 @@ impl Record {
     /// # Errors
     ///
     /// Returns error if tag is not present in header.
+    ///
+    /// # Example
+    ///
+    /// Example assumes we have a Record `record` from a VCF with an `AF` `FORMAT` tag.
+    /// See module documentation for how to set up VCF, header, and record.
+    ///
+    /// ```
+    /// # use rust_htslib::bcf::{Format, Writer};
+    /// # use rust_htslib::bcf::header::Header;
+    /// # use rust_htslib::bcf::record::GenotypeAllele;
+    /// # let mut header = Header::new();
+    /// # let header_contig_line = r#"##contig=<ID=1,length=10>"#;
+    /// # header.push_record(header_contig_line.as_bytes());
+    /// # let header_af_line = r#"##FORMAT=<ID=AF,Number=1,Type=Float,Description="Frequency">"#;
+    /// # header.push_record(header_af_line.as_bytes());
+    /// # header.push_sample("test_sample".as_bytes());
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut record = vcf.empty_record();
+    /// record.push_format_float(b"AF", &[0.5]);
+    /// assert_eq!(0.5, record.format(b"AF").float().unwrap()[0][0]);
+    /// ```
     pub fn push_format_float(&mut self, tag: &[u8], data: &[f32]) -> Result<()> {
         self.push_format(tag, data, htslib::BCF_HT_REAL)
     }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -185,7 +185,7 @@ impl Record {
     /// Get the reference id of the record.
     ///
     /// To look up the contig name,
-    /// use [HeaderView::rid2name](../header/struct.HeaderView.html#method.rid2name).
+    /// use [`HeaderView::rid2name`](../header/struct.HeaderView.html#method.rid2name).
     ///
     /// # Returns
     ///
@@ -201,12 +201,13 @@ impl Record {
     /// Update the reference id of the record.
     ///
     /// To look up reference id for a contig name,
-    /// use [HeaderView::name2rid](../header/struct.HeaderView.html#method.name2rid).
+    /// use [`HeaderView::name2rid`](../header/struct.HeaderView.html#method.name2rid).
     ///
     /// # Example
     ///
-    /// Example assumes we have a Record `record` from a VCF with a header containing region named `1`.
-    /// See module documentation for how to set up VCF, header, and record.
+    /// Example assumes we have a Record `record` from a VCF with a header containing region
+    /// named `1`. See [module documentation](../index.html#example-writing) for how to set
+    /// up VCF, header, and record.
     ///
     /// ```
     /// # use rust_htslib::bcf::{Format, Writer};
@@ -453,7 +454,8 @@ impl Record {
     /// # Example
     ///
     /// Example assumes we have a Record `record` from a VCF with a `GT` `FORMAT` tag.
-    /// See module documentation for how to set up VCF, header, and record.
+    /// See [module documentation](../index.html#example-writing) for how to set up
+    /// VCF, header, and record.
     ///
     /// ```
     /// # use rust_htslib::bcf::{Format, Writer};
@@ -545,7 +547,8 @@ impl Record {
     /// # Example
     ///
     /// Example assumes we have a Record `record` from a VCF with an `AF` `FORMAT` tag.
-    /// See module documentation for how to set up VCF, header, and record.
+    /// See [module documentation](../index.html#example-writing) for how to set up
+    /// VCF, header, and record.
     ///
     /// ```
     /// # use rust_htslib::bcf::{Format, Writer};


### PR DESCRIPTION
Addresses the remaining points in #224: 

- Adds `From<i32> for GenotypeAllele`, copying the code from the old `from_encoded` method. Also included a bit of testing for this in the tests for the previous `From<GenotypeAllele> for i32`, ensuring that converting back and forth does nothing.
- Replaces the only internal usage of `from_encoded`, deprecating the method from `0.36.0` onwards.
- Adds module level documentation for setting up a minimal VCF writer with header and a record with chrom, pos, and genotype information.
- Adds illustrative examples/doctests for three write methods for `Record`: `set_rid`, `push_genotypes`, and `push_format_float`.

The doc tests all require quite a bit of setup to compile. I've hidden this from the doc, with a note about the presuppositions and a reference to the module level docs, which gives a full example. I'm not sure this is the best way to do it, but including all the setup code seems to me to divert attention from the main point. 

Moreover, the setup requires a lot of code duplication, which is not nice, but I couldn't find a way to centralise the setup so long as `#[cfg(doctest)]` doesn't work for this case (see Rust issue [#67295](https://github.com/rust-lang/rust/issues/67295)).

Very happy to hear any other takes on how to organise this.