### PR TITLE
More Functionality for Auxiliary Fields of BAM Records (Support for All Types, Arrays, Iteration)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1"
 hts-sys = { version = "1.11.1-fix1", path = "hts-sys", default-features = false }
 derive-new = "0.5"
 ieee754 = "0.2"
+byteorder = "1.3.4"
 
 [features]
 default = ["bzip2", "lzma", "curl"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "1"
 hts-sys = { version = "1.11.1-fix1", path = "hts-sys", default-features = false }
 derive-new = "0.5"
 ieee754 = "0.2"
-byteorder = "1.3.4"
+byteorder = "1.3"
 
 [features]
 default = ["bzip2", "lzma", "curl"]

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2347,12 +2347,10 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_aux_arrays() {
-        use crate::bam;
-
-        let bam_header = bam::Header::new();
-        let mut test_record = bam::Record::from_sam(
-            &mut bam::HeaderView::from_header(&bam_header),
-            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT\tFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".as_bytes(),
+        let bam_header = Header::new();
+        let mut test_record = Record::from_sam(
+            &mut HeaderView::from_header(&bam_header),
+            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
         ).unwrap();
 
         let array_i8: Vec<i8> = vec![std::i8::MIN, -1, 0, 1, std::i8::MAX];
@@ -2679,13 +2677,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_aux_scalars() {
-        use crate::bam;
-
-        let bam_header = bam::Header::new();
-        let mut test_record = bam::Record::from_sam(
-            &mut bam::HeaderView::from_header(&bam_header),
-            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT\tFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".as_bytes(),
-        ).unwrap();
+        let bam_header = Header::new();
+        let mut test_record = Record::from_sam(
+            &mut HeaderView::from_header(&bam_header),
+            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
+        )
+        .unwrap();
 
         test_record.push_aux(b"XA", Aux::I8(i8::MIN)).unwrap();
         test_record.push_aux(b"XB", Aux::I8(i8::MAX)).unwrap();

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2645,4 +2645,61 @@ CCCCCCCCCCCCCCCCCCC"[..],
             }
         }
     }
+
+    #[test]
+    fn test_aux_scalars() {
+        use crate::bam;
+
+        let bam_header = bam::Header::new();
+        let mut test_record = bam::Record::from_sam(
+            &mut bam::HeaderView::from_header(&bam_header),
+            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT\tFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".as_bytes(),
+        ).unwrap();
+
+        test_record.push_aux(b"XA", Aux::I8(i8::MIN)).unwrap();
+        test_record.push_aux(b"XB", Aux::I8(i8::MAX)).unwrap();
+        test_record.push_aux(b"XC", Aux::U8(u8::MIN)).unwrap();
+        test_record.push_aux(b"XD", Aux::U8(u8::MAX)).unwrap();
+        test_record.push_aux(b"XE", Aux::I16(i16::MIN)).unwrap();
+        test_record.push_aux(b"XF", Aux::I16(i16::MAX)).unwrap();
+        test_record.push_aux(b"XG", Aux::U16(u16::MIN)).unwrap();
+        test_record.push_aux(b"XH", Aux::U16(u16::MAX)).unwrap();
+        test_record.push_aux(b"XI", Aux::I32(i32::MIN)).unwrap();
+        test_record.push_aux(b"XJ", Aux::I32(i32::MAX)).unwrap();
+        test_record.push_aux(b"XK", Aux::U32(u32::MIN)).unwrap();
+        test_record.push_aux(b"XL", Aux::U32(u32::MAX)).unwrap();
+        test_record
+            .push_aux(b"XM", Aux::Float(std::f32::consts::PI))
+            .unwrap();
+        test_record
+            .push_aux(b"XN", Aux::Double(std::f64::consts::PI))
+            .unwrap();
+        test_record
+            .push_aux(b"XO", Aux::String("Test str"))
+            .unwrap();
+        test_record.push_aux(b"XP", Aux::I8(0)).unwrap();
+
+        let collected_aux_fields = test_record.aux_iter().collect::<Result<Vec<_>>>().unwrap();
+        assert_eq!(
+            collected_aux_fields,
+            vec![
+                (&b"XA"[..], Aux::I8(i8::MIN)),
+                (&b"XB"[..], Aux::I8(i8::MAX)),
+                (&b"XC"[..], Aux::U8(u8::MIN)),
+                (&b"XD"[..], Aux::U8(u8::MAX)),
+                (&b"XE"[..], Aux::I16(i16::MIN)),
+                (&b"XF"[..], Aux::I16(i16::MAX)),
+                (&b"XG"[..], Aux::U16(u16::MIN)),
+                (&b"XH"[..], Aux::U16(u16::MAX)),
+                (&b"XI"[..], Aux::I32(i32::MIN)),
+                (&b"XJ"[..], Aux::I32(i32::MAX)),
+                (&b"XK"[..], Aux::U32(u32::MIN)),
+                (&b"XL"[..], Aux::U32(u32::MAX)),
+                (&b"XM"[..], Aux::Float(std::f32::consts::PI)),
+                (&b"XN"[..], Aux::Double(std::f64::consts::PI)),
+                (&b"XO"[..], Aux::String("Test str")),
+                (&b"XP"[..], Aux::I8(0)),
+            ]
+        );
+    }
 }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2352,8 +2352,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let mut test_record = bam::Record::from_sam(
             &mut bam::HeaderView::from_header(&bam_header),
             "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT\tFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".as_bytes(),
-        )
-            .unwrap();
+        ).unwrap();
 
         let array_i8: Vec<i8> = vec![std::i8::MIN, -1, 0, 1, std::i8::MAX];
         let array_u8: Vec<u8> = vec![std::u8::MIN, 0, 1, std::u8::MAX];
@@ -2363,66 +2362,51 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let array_u32: Vec<u32> = vec![std::u32::MIN, 0, 1, std::u32::MAX];
         let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
 
-        test_record.push_aux(b"XA", bam::record::Aux::ArrayI8(array_i8.as_slice().into()));
-        test_record.push_aux(b"XB", bam::record::Aux::ArrayU8(array_u8.as_slice().into()));
-        test_record.push_aux(
-            b"XC",
-            bam::record::Aux::ArrayI16(array_i16.as_slice().into()),
-        );
-        test_record.push_aux(
-            b"XD",
-            bam::record::Aux::ArrayU16(array_u16.as_slice().into()),
-        );
-        test_record.push_aux(
-            b"XE",
-            bam::record::Aux::ArrayI32(array_i32.as_slice().into()),
-        );
-        test_record.push_aux(
-            b"XF",
-            bam::record::Aux::ArrayU32(array_u32.as_slice().into()),
-        );
-        test_record.push_aux(
-            b"XG",
-            bam::record::Aux::ArrayFloat(array_f32.as_slice().into()),
-        );
+        test_record.push_aux(b"XA", Aux::ArrayI8(array_i8.as_slice().into()));
+        test_record.push_aux(b"XB", Aux::ArrayU8(array_u8.as_slice().into()));
+        test_record.push_aux(b"XC", Aux::ArrayI16(array_i16.as_slice().into()));
+        test_record.push_aux(b"XD", Aux::ArrayU16(array_u16.as_slice().into()));
+        test_record.push_aux(b"XE", Aux::ArrayI32(array_i32.as_slice().into()));
+        test_record.push_aux(b"XF", Aux::ArrayU32(array_u32.as_slice().into()));
+        test_record.push_aux(b"XG", Aux::ArrayFloat(array_f32.as_slice().into()));
 
-        if let bam::record::Aux::ArrayI8(array) = test_record.aux(b"XA").unwrap() {
+        if let Some(Aux::ArrayI8(array)) = test_record.aux(b"XA") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_i8);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayU8(array) = test_record.aux(b"XB").unwrap() {
+        if let Some(Aux::ArrayU8(array)) = test_record.aux(b"XB") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_u8);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayI16(array) = test_record.aux(b"XC").unwrap() {
+        if let Some(Aux::ArrayI16(array)) = test_record.aux(b"XC") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_i16);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayU16(array) = test_record.aux(b"XD").unwrap() {
+        if let Some(Aux::ArrayU16(array)) = test_record.aux(b"XD") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_u16);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayI32(array) = test_record.aux(b"XE").unwrap() {
+        if let Some(Aux::ArrayI32(array)) = test_record.aux(b"XE") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_i32);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayU32(array) = test_record.aux(b"XF").unwrap() {
+        if let Some(Aux::ArrayU32(array)) = test_record.aux(b"XF") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_u32);
         } else {
             panic!("Aux tag not found");
         }
-        if let bam::record::Aux::ArrayFloat(array) = test_record.aux(b"XG").unwrap() {
+        if let Some(Aux::ArrayFloat(array)) = test_record.aux(b"XG") {
             let aux_array_content = array.iter().collect::<Vec<_>>();
             assert_eq!(aux_array_content, array_f32);
         } else {

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1303,6 +1303,7 @@ mod tests {
     use super::header::HeaderRecord;
     use super::record::{Aux, Cigar, CigarString};
     use super::*;
+    use crate::errors::Error::BamAuxTagNotFound;
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
@@ -1501,7 +1502,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // fix qual offset
             let qual: Vec<u8> = quals[i].iter().map(|&q| q - 33).collect();
             assert_eq!(rec.qual(), &qual[..]);
-            assert_eq!(rec.aux(b"NotAvailableAux"), None);
+            assert_eq!(rec.aux(b"NotAvailableAux"), Err(BamAuxTagNotFound));
         }
 
         // fetch to empty position
@@ -1551,7 +1552,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // fix qual offset
             let qual: Vec<u8> = quals[i].iter().map(|&q| q - 33).collect();
             assert_eq!(rec.qual(), &qual[..]);
-            assert_eq!(rec.aux(b"NotAvailableAux"), None);
+            assert_eq!(rec.aux(b"NotAvailableAux"), Err(Error::BamAuxTagNotFound));
         }
 
         // fetch to empty position
@@ -1745,18 +1746,18 @@ CCCCCCCCCCCCCCCCCCC"[..],
         for record in bam.records() {
             let mut rec = record.expect("Expected valid record");
 
-            if rec.aux(b"XS").is_some() {
+            if rec.aux(b"XS").is_ok() {
                 rec.remove_aux(b"XS");
             }
 
-            if rec.aux(b"YT").is_some() {
+            if rec.aux(b"YT").is_ok() {
                 rec.remove_aux(b"YT");
             }
 
             rec.remove_aux(b"ab");
 
-            assert_eq!(rec.aux(b"XS"), None);
-            assert_eq!(rec.aux(b"YT"), None);
+            assert_eq!(rec.aux(b"XS"), Err(Error::BamAuxTagNotFound));
+            assert_eq!(rec.aux(b"YT"), Err(Error::BamAuxTagNotFound));
         }
     }
 
@@ -2386,7 +2387,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XA";
-            if let Some(Aux::ArrayI8(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayI8(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_i8);
@@ -2400,12 +2401,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayI8(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayI8(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_i8);
                     } else {
@@ -2419,7 +2420,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XB";
-            if let Some(Aux::ArrayU8(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayU8(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_u8);
@@ -2433,12 +2434,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayU8(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayU8(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_u8);
                     } else {
@@ -2452,7 +2453,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XC";
-            if let Some(Aux::ArrayI16(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayI16(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_i16);
@@ -2466,12 +2467,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayI16(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayI16(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_i16);
                     } else {
@@ -2485,7 +2486,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XD";
-            if let Some(Aux::ArrayU16(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayU16(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_u16);
@@ -2499,12 +2500,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayU16(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayU16(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_u16);
                     } else {
@@ -2518,7 +2519,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XE";
-            if let Some(Aux::ArrayI32(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayI32(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_i32);
@@ -2532,12 +2533,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayI32(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayI32(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_i32);
                     } else {
@@ -2551,7 +2552,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XF";
-            if let Some(Aux::ArrayU32(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayU32(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_u32);
@@ -2565,12 +2566,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayU32(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayU32(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_u32);
                     } else {
@@ -2584,7 +2585,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
         {
             let tag = b"XG";
-            if let Some(Aux::ArrayFloat(array)) = test_record.aux(tag) {
+            if let Ok(Aux::ArrayFloat(array)) = test_record.aux(tag) {
                 // Retrieve aux array
                 let aux_array_content = array.iter().collect::<Vec<_>>();
                 assert_eq!(aux_array_content, array_f32);
@@ -2598,12 +2599,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
                     // Remove aux array from target record
                     copy_test_record.remove_aux(tag);
-                    assert!(copy_test_record.aux(tag).is_none());
+                    assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
                     let src_aux = test_record.aux(tag).unwrap();
                     assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
-                    if let Some(Aux::ArrayFloat(array)) = copy_test_record.aux(tag) {
+                    if let Ok(Aux::ArrayFloat(array)) = copy_test_record.aux(tag) {
                         let aux_array_content_copied = array.iter().collect::<Vec<_>>();
                         assert_eq!(aux_array_content_copied, array_f32);
                     } else {

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2364,25 +2364,25 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
 
         assert!(test_record
-            .push_aux(b"XA", Aux::ArrayI8(array_i8.as_slice().into()))
+            .push_aux(b"XA", Aux::ArrayI8((&array_i8).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XB", Aux::ArrayU8(array_u8.as_slice().into()))
+            .push_aux(b"XB", Aux::ArrayU8((&array_u8).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XC", Aux::ArrayI16(array_i16.as_slice().into()))
+            .push_aux(b"XC", Aux::ArrayI16((&array_i16).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XD", Aux::ArrayU16(array_u16.as_slice().into()))
+            .push_aux(b"XD", Aux::ArrayU16((&array_u16).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XE", Aux::ArrayI32(array_i32.as_slice().into()))
+            .push_aux(b"XE", Aux::ArrayI32((&array_i32).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XF", Aux::ArrayU32(array_u32.as_slice().into()))
+            .push_aux(b"XF", Aux::ArrayU32((&array_u32).into()))
             .is_ok());
         assert!(test_record
-            .push_aux(b"XG", Aux::ArrayFloat(array_f32.as_slice().into()))
+            .push_aux(b"XG", Aux::ArrayFloat((&array_f32).into()))
             .is_ok());
 
         {
@@ -2615,5 +2615,9 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 panic!("Aux tag not found");
             }
         }
+
+        // let all_aux_data = test_record.aux_iter().collect::<Vec<_>>();
+        // dbg!(&all_aux_data);
+        // panic!();
     }
 }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1617,7 +1617,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         rec.set(names[0], Some(&cigars[0]), seqs[0], quals[0]);
         // note: this segfaults if you push_aux() before set()
         //       because set() obliterates aux
-        rec.push_aux(b"NM", Aux::I32(15));
+        rec.push_aux(b"NM", Aux::I32(15)).unwrap();
 
         assert_eq!(rec.qname(), names[0]);
         assert_eq!(*rec.cigar(), cigars[0]);
@@ -1636,7 +1636,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             b"AAA",
             b"III",
         );
-        rec.push_aux(b"AS", Aux::I32(12345));
+        rec.push_aux(b"AS", Aux::I32(12345)).unwrap();
         assert_eq!(rec.qname(), b"123");
         assert_eq!(rec.seq().as_bytes(), b"AAA");
         assert_eq!(rec.qual(), b"III");
@@ -1674,7 +1674,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         for i in 0..names.len() {
             let mut rec = record::Record::new();
             rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-            rec.push_aux(b"NM", Aux::I32(15));
+            rec.push_aux(b"NM", Aux::I32(15)).unwrap();
 
             assert_eq!(rec.qname(), names[i]);
             assert_eq!(*rec.cigar(), cigars[i]);
@@ -1786,7 +1786,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
                 rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-                rec.push_aux(b"NM", Aux::I32(15));
+                rec.push_aux(b"NM", Aux::I32(15)).unwrap();
 
                 bam.write(&rec).expect("Failed to write record.");
             }
@@ -1840,7 +1840,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
                 rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
-                rec.push_aux(b"NM", Aux::I32(15));
+                rec.push_aux(b"NM", Aux::I32(15)).unwrap();
                 rec.set_pos(i as i64);
 
                 bam.write(&rec).expect("Failed to write record.");
@@ -1913,7 +1913,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
                 rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
-                rec.push_aux(b"NM", Aux::I32(15));
+                rec.push_aux(b"NM", Aux::I32(15)).unwrap();
                 rec.set_pos(i as i64);
 
                 bam1.write(&rec).expect("Failed to write record.");

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2362,55 +2362,257 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let array_u32: Vec<u32> = vec![std::u32::MIN, 0, 1, std::u32::MAX];
         let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
 
-        test_record.push_aux(b"XA", Aux::ArrayI8(array_i8.as_slice().into()));
-        test_record.push_aux(b"XB", Aux::ArrayU8(array_u8.as_slice().into()));
-        test_record.push_aux(b"XC", Aux::ArrayI16(array_i16.as_slice().into()));
-        test_record.push_aux(b"XD", Aux::ArrayU16(array_u16.as_slice().into()));
-        test_record.push_aux(b"XE", Aux::ArrayI32(array_i32.as_slice().into()));
-        test_record.push_aux(b"XF", Aux::ArrayU32(array_u32.as_slice().into()));
-        test_record.push_aux(b"XG", Aux::ArrayFloat(array_f32.as_slice().into()));
+        assert!(test_record
+            .push_aux(b"XA", Aux::ArrayI8(array_i8.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XB", Aux::ArrayU8(array_u8.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XC", Aux::ArrayI16(array_i16.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XD", Aux::ArrayU16(array_u16.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XE", Aux::ArrayI32(array_i32.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XF", Aux::ArrayU32(array_u32.as_slice().into()))
+            .is_ok());
+        assert!(test_record
+            .push_aux(b"XG", Aux::ArrayFloat(array_f32.as_slice().into()))
+            .is_ok());
 
-        if let Some(Aux::ArrayI8(array)) = test_record.aux(b"XA") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_i8);
-        } else {
-            panic!("Aux tag not found");
+        {
+            let tag = b"XA";
+            if let Some(Aux::ArrayI8(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_i8);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::I8(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayI8(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_i8);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayU8(array)) = test_record.aux(b"XB") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_u8);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XB";
+            if let Some(Aux::ArrayU8(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_u8);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::U8(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayU8(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_u8);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayI16(array)) = test_record.aux(b"XC") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_i16);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XC";
+            if let Some(Aux::ArrayI16(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_i16);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::I16(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayI16(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_i16);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayU16(array)) = test_record.aux(b"XD") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_u16);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XD";
+            if let Some(Aux::ArrayU16(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_u16);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::U16(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayU16(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_u16);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayI32(array)) = test_record.aux(b"XE") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_i32);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XE";
+            if let Some(Aux::ArrayI32(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_i32);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::I32(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayI32(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_i32);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayU32(array)) = test_record.aux(b"XF") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_u32);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XF";
+            if let Some(Aux::ArrayU32(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_u32);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::U32(3)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayU32(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_u32);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
-        if let Some(Aux::ArrayFloat(array)) = test_record.aux(b"XG") {
-            let aux_array_content = array.iter().collect::<Vec<_>>();
-            assert_eq!(aux_array_content, array_f32);
-        } else {
-            panic!("Aux tag not found");
+
+        {
+            let tag = b"XG";
+            if let Some(Aux::ArrayFloat(array)) = test_record.aux(tag) {
+                // Retrieve aux array
+                let aux_array_content = array.iter().collect::<Vec<_>>();
+                assert_eq!(aux_array_content, array_f32);
+
+                // Copy the stored aux array to another record
+                {
+                    let mut copy_test_record = test_record.clone();
+
+                    // Pushing a field with an existing tag should fail
+                    assert!(copy_test_record.push_aux(tag, Aux::Float(3.0)).is_err());
+
+                    // Remove aux array from target record
+                    copy_test_record.remove_aux(tag);
+                    assert!(copy_test_record.aux(tag).is_none());
+
+                    // Copy array to target record
+                    let src_aux = test_record.aux(tag).unwrap();
+                    assert!(copy_test_record.push_aux(tag, src_aux).is_ok());
+                    if let Some(Aux::ArrayFloat(array)) = copy_test_record.aux(tag) {
+                        let aux_array_content_copied = array.iter().collect::<Vec<_>>();
+                        assert_eq!(aux_array_content_copied, array_f32);
+                    } else {
+                        panic!("Aux tag not found");
+                    }
+                }
+            } else {
+                panic!("Aux tag not found");
+            }
         }
     }
 }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2343,4 +2343,90 @@ CCCCCCCCCCCCCCCCCCC"[..],
             assert_eq!(rec.qual(), &qual[..]);
         }
     }
+
+    #[test]
+    fn test_aux() {
+        use crate::bam;
+
+        let bam_header = bam::Header::new();
+        let mut test_record = bam::Record::from_sam(
+            &mut bam::HeaderView::from_header(&bam_header),
+            "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tAAAACCCCGGGGTTTTAAAACCCCGGGGTTTTAAAACCCCGGGGTTTT\tFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF".as_bytes(),
+        )
+            .unwrap();
+
+        let array_i8: Vec<i8> = vec![std::i8::MIN, -1, 0, 1, std::i8::MAX];
+        let array_u8: Vec<u8> = vec![std::u8::MIN, 0, 1, std::u8::MAX];
+        let array_i16: Vec<i16> = vec![std::i16::MIN, -1, 0, 1, std::i16::MAX];
+        let array_u16: Vec<u16> = vec![std::u16::MIN, 0, 1, std::u16::MAX];
+        let array_i32: Vec<i32> = vec![std::i32::MIN, -1, 0, 1, std::i32::MAX];
+        let array_u32: Vec<u32> = vec![std::u32::MIN, 0, 1, std::u32::MAX];
+        let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
+
+        test_record.push_aux(b"XA", bam::record::Aux::ArrayI8(array_i8.as_slice().into()));
+        test_record.push_aux(b"XB", bam::record::Aux::ArrayU8(array_u8.as_slice().into()));
+        test_record.push_aux(
+            b"XC",
+            bam::record::Aux::ArrayI16(array_i16.as_slice().into()),
+        );
+        test_record.push_aux(
+            b"XD",
+            bam::record::Aux::ArrayU16(array_u16.as_slice().into()),
+        );
+        test_record.push_aux(
+            b"XE",
+            bam::record::Aux::ArrayI32(array_i32.as_slice().into()),
+        );
+        test_record.push_aux(
+            b"XF",
+            bam::record::Aux::ArrayU32(array_u32.as_slice().into()),
+        );
+        test_record.push_aux(
+            b"XG",
+            bam::record::Aux::ArrayFloat(array_f32.as_slice().into()),
+        );
+
+        if let bam::record::Aux::ArrayI8(array) = test_record.aux(b"XA").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_i8);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayU8(array) = test_record.aux(b"XB").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_u8);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayI16(array) = test_record.aux(b"XC").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_i16);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayU16(array) = test_record.aux(b"XD").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_u16);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayI32(array) = test_record.aux(b"XE").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_i32);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayU32(array) = test_record.aux(b"XF").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_u32);
+        } else {
+            panic!("Aux tag not found");
+        }
+        if let bam::record::Aux::ArrayFloat(array) = test_record.aux(b"XG").unwrap() {
+            let aux_array_content = array.iter().collect::<Vec<_>>();
+            assert_eq!(aux_array_content, array_f32);
+        } else {
+            panic!("Aux tag not found");
+        }
+    }
 }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2363,27 +2363,27 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let array_u32: Vec<u32> = vec![std::u32::MIN, 0, 1, std::u32::MAX];
         let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
 
-        assert!(test_record
+        test_record
             .push_aux(b"XA", Aux::ArrayI8((&array_i8).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XB", Aux::ArrayU8((&array_u8).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XC", Aux::ArrayI16((&array_i16).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XD", Aux::ArrayU16((&array_u16).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XE", Aux::ArrayI32((&array_i32).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XF", Aux::ArrayU32((&array_u32).into()))
-            .is_ok());
-        assert!(test_record
+            .unwrap();
+        test_record
             .push_aux(b"XG", Aux::ArrayFloat((&array_f32).into()))
-            .is_ok());
+            .unwrap();
 
         {
             let tag = b"XA";

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1303,7 +1303,6 @@ mod tests {
     use super::header::HeaderRecord;
     use super::record::{Aux, Cigar, CigarString};
     use super::*;
-    use crate::errors::Error::BamAuxTagNotFound;
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
@@ -1502,7 +1501,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // fix qual offset
             let qual: Vec<u8> = quals[i].iter().map(|&q| q - 33).collect();
             assert_eq!(rec.qual(), &qual[..]);
-            assert_eq!(rec.aux(b"NotAvailableAux"), Err(BamAuxTagNotFound));
+            assert_eq!(rec.aux(b"NotAvailableAux"), Err(Error::BamAuxTagNotFound));
         }
 
         // fetch to empty position
@@ -2351,7 +2350,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let mut test_record = Record::from_sam(
             &mut HeaderView::from_header(&bam_header),
             "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
-        ).unwrap();
+        )
+        .unwrap();
 
         let array_i8: Vec<i8> = vec![std::i8::MIN, -1, 0, 1, std::i8::MAX];
         let array_u8: Vec<u8> = vec![std::u8::MIN, 0, 1, std::u8::MAX];

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1747,14 +1747,14 @@ CCCCCCCCCCCCCCCCCCC"[..],
             let mut rec = record.expect("Expected valid record");
 
             if rec.aux(b"XS").is_ok() {
-                rec.remove_aux(b"XS");
+                rec.remove_aux(b"XS").unwrap();
             }
 
             if rec.aux(b"YT").is_ok() {
-                rec.remove_aux(b"YT");
+                rec.remove_aux(b"YT").unwrap();
             }
 
-            rec.remove_aux(b"ab");
+            assert!(rec.remove_aux(b"ab").is_err());
 
             assert_eq!(rec.aux(b"XS"), Err(Error::BamAuxTagNotFound));
             assert_eq!(rec.aux(b"YT"), Err(Error::BamAuxTagNotFound));
@@ -2400,7 +2400,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::I8(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2433,7 +2433,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::U8(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2466,7 +2466,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::I16(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2499,7 +2499,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::U16(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2532,7 +2532,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::I32(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2565,7 +2565,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::U32(3)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record
@@ -2598,7 +2598,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert!(copy_test_record.push_aux(tag, Aux::Float(3.0)).is_err());
 
                     // Remove aux array from target record
-                    copy_test_record.remove_aux(tag);
+                    copy_test_record.remove_aux(tag).unwrap();
                     assert!(copy_test_record.aux(tag).is_err());
 
                     // Copy array to target record

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -1616,14 +1616,14 @@ CCCCCCCCCCCCCCCCCCC"[..],
         rec.set(names[0], Some(&cigars[0]), seqs[0], quals[0]);
         // note: this segfaults if you push_aux() before set()
         //       because set() obliterates aux
-        rec.push_aux(b"NM", &Aux::Integer(15));
+        rec.push_aux(b"NM", Aux::I32(15));
 
         assert_eq!(rec.qname(), names[0]);
         assert_eq!(*rec.cigar(), cigars[0]);
         assert_eq!(rec.seq().as_bytes(), seqs[0]);
         assert_eq!(rec.qual(), quals[0]);
         assert!(rec.is_reverse());
-        assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+        assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
     }
 
     #[test]
@@ -1635,11 +1635,11 @@ CCCCCCCCCCCCCCCCCCC"[..],
             b"AAA",
             b"III",
         );
-        rec.push_aux(b"AS", &Aux::Integer(12345));
+        rec.push_aux(b"AS", Aux::I32(12345));
         assert_eq!(rec.qname(), b"123");
         assert_eq!(rec.seq().as_bytes(), b"AAA");
         assert_eq!(rec.qual(), b"III");
-        assert_eq!(rec.aux(b"AS").unwrap(), Aux::Integer(12345));
+        assert_eq!(rec.aux(b"AS").unwrap(), Aux::I32(12345));
 
         rec.set(
             b"1234",
@@ -1650,7 +1650,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         assert_eq!(rec.qname(), b"1234");
         assert_eq!(rec.seq().as_bytes(), b"AAAA");
         assert_eq!(rec.qual(), b"IIII");
-        assert_eq!(rec.aux(b"AS").unwrap(), Aux::Integer(12345));
+        assert_eq!(rec.aux(b"AS").unwrap(), Aux::I32(12345));
 
         rec.set(
             b"12",
@@ -1661,7 +1661,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         assert_eq!(rec.qname(), b"12");
         assert_eq!(rec.seq().as_bytes(), b"AA");
         assert_eq!(rec.qual(), b"II");
-        assert_eq!(rec.aux(b"AS").unwrap(), Aux::Integer(12345));
+        assert_eq!(rec.aux(b"AS").unwrap(), Aux::I32(12345));
     }
 
     #[test]
@@ -1673,13 +1673,13 @@ CCCCCCCCCCCCCCCCCCC"[..],
         for i in 0..names.len() {
             let mut rec = record::Record::new();
             rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-            rec.push_aux(b"NM", &Aux::Integer(15));
+            rec.push_aux(b"NM", Aux::I32(15));
 
             assert_eq!(rec.qname(), names[i]);
             assert_eq!(*rec.cigar(), cigars[i]);
             assert_eq!(rec.seq().as_bytes(), seqs[i]);
             assert_eq!(rec.qual(), quals[i]);
-            assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+            assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
 
             // Equal length qname
             assert!(rec.qname()[0] != b'X');
@@ -1696,7 +1696,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             assert_eq!(*rec.cigar(), cigars[i]);
             assert_eq!(rec.seq().as_bytes(), seqs[i]);
             assert_eq!(rec.qual(), quals[i]);
-            assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+            assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
 
             // Shorter qname
             let shorter_name = b"42";
@@ -1706,7 +1706,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             assert_eq!(*rec.cigar(), cigars[i]);
             assert_eq!(rec.seq().as_bytes(), seqs[i]);
             assert_eq!(rec.qual(), quals[i]);
-            assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+            assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
 
             // Zero-length qname
             rec.set_qname(b"");
@@ -1715,7 +1715,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             assert_eq!(*rec.cigar(), cigars[i]);
             assert_eq!(rec.seq().as_bytes(), seqs[i]);
             assert_eq!(rec.qual(), quals[i]);
-            assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+            assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
         }
     }
 
@@ -1785,7 +1785,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
                 rec.set(names[i], Some(&cigars[i]), seqs[i], quals[i]);
-                rec.push_aux(b"NM", &Aux::Integer(15));
+                rec.push_aux(b"NM", Aux::I32(15));
 
                 bam.write(&rec).expect("Failed to write record.");
             }
@@ -1805,7 +1805,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 assert_eq!(*rec.cigar(), cigars[i]);
                 assert_eq!(rec.seq().as_bytes(), seqs[i]);
                 assert_eq!(rec.qual(), quals[i]);
-                assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+                assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
             }
         }
 
@@ -1839,7 +1839,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
                 rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
-                rec.push_aux(b"NM", &Aux::Integer(15));
+                rec.push_aux(b"NM", Aux::I32(15));
                 rec.set_pos(i as i64);
 
                 bam.write(&rec).expect("Failed to write record.");
@@ -1859,7 +1859,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 assert_eq!(*rec.cigar(), cigars[idx]);
                 assert_eq!(rec.seq().as_bytes(), seqs[idx]);
                 assert_eq!(rec.qual(), quals[idx]);
-                assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+                assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
             }
         }
 
@@ -1912,7 +1912,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 let mut rec = record::Record::new();
                 let idx = i % names.len();
                 rec.set(names[idx], Some(&cigars[idx]), seqs[idx], quals[idx]);
-                rec.push_aux(b"NM", &Aux::Integer(15));
+                rec.push_aux(b"NM", Aux::I32(15));
                 rec.set_pos(i as i64);
 
                 bam1.write(&rec).expect("Failed to write record.");
@@ -1937,7 +1937,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     assert_eq!(*rec.cigar(), cigars[idx]);
                     assert_eq!(rec.seq().as_bytes(), seqs[idx]);
                     assert_eq!(rec.qual(), quals[idx]);
-                    assert_eq!(rec.aux(b"NM").unwrap(), Aux::Integer(15));
+                    assert_eq!(rec.aux(b"NM").unwrap(), Aux::I32(15));
                 }
             }
         }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -2346,7 +2346,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     }
 
     #[test]
-    fn test_aux() {
+    fn test_aux_arrays() {
         use crate::bam;
 
         let bam_header = bam::Header::new();
@@ -2616,8 +2616,33 @@ CCCCCCCCCCCCCCCCCCC"[..],
             }
         }
 
-        // let all_aux_data = test_record.aux_iter().collect::<Vec<_>>();
-        // dbg!(&all_aux_data);
-        // panic!();
+        for item in test_record.aux_iter() {
+            match item.unwrap() {
+                (b"XA", Aux::ArrayI8(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_i8);
+                }
+                (b"XB", Aux::ArrayU8(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_u8);
+                }
+                (b"XC", Aux::ArrayI16(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_i16);
+                }
+                (b"XD", Aux::ArrayU16(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_u16);
+                }
+                (b"XE", Aux::ArrayI32(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_i32);
+                }
+                (b"XF", Aux::ArrayU32(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_u32);
+                }
+                (b"XG", Aux::ArrayFloat(array)) => {
+                    assert_eq!(&array.iter().collect::<Vec<_>>(), &array_f32);
+                }
+                _ => {
+                    panic!();
+                }
+            }
+        }
     }
 }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -838,16 +838,6 @@ pub enum Aux<'a> {
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
 
-pub trait AuxArrayElement: Copy {}
-
-impl AuxArrayElement for i8 {}
-impl AuxArrayElement for u8 {}
-impl AuxArrayElement for i16 {}
-impl AuxArrayElement for u16 {}
-impl AuxArrayElement for i32 {}
-impl AuxArrayElement for u32 {}
-impl AuxArrayElement for f32 {}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuxArray<'a, T: AuxArrayElement> {
     data_type: PhantomData<T>,

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -579,7 +579,7 @@ impl Record {
     /// Only the first two bytes of a given tag are used for the look-up of a field.
     /// See [`Aux`] for more details.
     pub fn aux(&self, tag: &[u8]) -> Result<Aux<'_>> {
-        let c_str = ffi::CString::new(tag).unwrap();
+        let c_str = ffi::CString::new(tag).map_err(|_| Error::BamAuxStringError)?;
         let aux = unsafe {
             htslib::bam_aux_get(
                 &self.inner as *const htslib::bam1_t,

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -6,7 +6,6 @@
 use std::convert::TryFrom;
 use std::ffi;
 use std::fmt;
-use std::marker::PhantomData;
 use std::mem::{size_of, MaybeUninit};
 use std::ops;
 use std::rc::Rc;
@@ -848,11 +847,17 @@ impl AuxArrayElement for i32 {}
 impl AuxArrayElement for u32 {}
 impl AuxArrayElement for f32 {}
 
+enum AuxArrayDataType<'a, T> {
+    TargetType(&'a [T]),
+    RawBytes(&'a [u8]),
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuxArray<'a, T: AuxArrayElement> {
-    data_type: PhantomData<T>,
-    array: &'a [u8],
+    array: AuxArrayDataType<'a, T>,
 }
+
+impl<'a, T> AuxArray<'a, T> where T: AuxArrayElement {}
 
 static DECODE_BASE: &[u8] = b"=ACMGRSVTWYHKDBN";
 static ENCODE_BASE: [u8; 256] = [

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -698,49 +698,43 @@ impl Record {
 
         match tag_type {
             b'c' => Some((
-                Aux::ArrayI8(AuxArray::<'a, i8>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length,
-                ))),
+                Aux::ArrayI8(StandardAuxArray::<'a, i8>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length),
+                )),
                 length,
             )),
             b'C' => Some((
-                Aux::ArrayU8(AuxArray::<'a, u8>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length,
-                ))),
+                Aux::ArrayU8(StandardAuxArray::<'a, u8>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length),
+                )),
                 length,
             )),
             b's' => Some((
-                Aux::ArrayI16(AuxArray::<'a, i16>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length * size_of::<i16>(),
-                ))),
+                Aux::ArrayI16(StandardAuxArray::<'a, i16>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<i16>()),
+                )),
                 length,
             )),
             b'S' => Some((
-                Aux::ArrayU16(AuxArray::<'a, u16>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length * size_of::<u16>(),
-                ))),
+                Aux::ArrayU16(StandardAuxArray::<'a, u16>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<u16>()),
+                )),
                 length,
             )),
             b'i' => Some((
-                Aux::ArrayI32(AuxArray::<'a, i32>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length * size_of::<i32>(),
-                ))),
+                Aux::ArrayI32(StandardAuxArray::<'a, i32>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<i32>()),
+                )),
                 length,
             )),
             b'I' => Some((
-                Aux::ArrayU32(AuxArray::<'a, u32>::from_bytes(slice::from_raw_parts(
-                    aux.offset(OFFSET),
-                    length * size_of::<u32>(),
-                ))),
+                Aux::ArrayU32(StandardAuxArray::<'a, u32>::from_bytes(
+                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<u32>()),
+                )),
                 length,
             )),
             b'f' => Some((
-                Aux::ArrayFloat(AuxArray::<f32>::from_bytes(slice::from_raw_parts(
+                Aux::ArrayFloat(StandardAuxArray::<f32>::from_bytes(slice::from_raw_parts(
                     aux.offset(OFFSET),
                     length * size_of::<f32>(),
                 ))),
@@ -840,49 +834,49 @@ impl Record {
                     )
                 }
                 // Not sure it's safe casting an immutable slice to a mutable pointer here
-                Aux::ArrayI8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI8(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'c',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU8(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'C',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayI16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI16(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b's',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU16(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'S',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayI32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI32(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'i',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU32(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'I',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayFloat(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayFloat(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'f',
@@ -1077,20 +1071,20 @@ pub enum Aux<'a> {
     Double(f64), // Not part of specs but implemented in `htslib`
     String(&'a str),
     HexByteArray(&'a str),
-    ArrayI8(AuxArray<'a, i8>),
-    ArrayU8(AuxArray<'a, u8>),
-    ArrayI16(AuxArray<'a, i16>),
-    ArrayU16(AuxArray<'a, u16>),
-    ArrayI32(AuxArray<'a, i32>),
-    ArrayU32(AuxArray<'a, u32>),
-    ArrayFloat(AuxArray<'a, f32>),
+    ArrayI8(StandardAuxArray<'a, i8>),
+    ArrayU8(StandardAuxArray<'a, u8>),
+    ArrayI16(StandardAuxArray<'a, i16>),
+    ArrayU16(StandardAuxArray<'a, u16>),
+    ArrayI32(StandardAuxArray<'a, i32>),
+    ArrayU32(StandardAuxArray<'a, u32>),
+    ArrayFloat(StandardAuxArray<'a, f32>),
 }
 
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
 
 #[derive(Debug, PartialEq)]
-pub enum AuxArray<'a, T> {
+pub enum StandardAuxArray<'a, T> {
     TargetType(&'a [T]),
     RawType(&'a [u8]),
 }
@@ -1106,21 +1100,25 @@ impl AuxArrayElement for u32 {}
 impl AuxArrayElement for f32 {}
 
 /// Create AuxArrays from slices of allowed target types
-impl<'a, T> From<&'a [T]> for AuxArray<'a, T>
+impl<'a, T> From<&'a [T]> for StandardAuxArray<'a, T>
 where
     T: AuxArrayElement,
 {
     fn from(src: &'a [T]) -> Self {
-        AuxArray::TargetType(src)
+        StandardAuxArray::TargetType(src)
     }
 }
 
-pub trait AuxArrayTrait {
+pub trait AuxArray {
     type Type;
     fn get(&self, index: usize) -> Option<Self::Type>;
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
-impl<'a, T> AuxArray<'a, T>
+impl<'a, T> StandardAuxArray<'a, T>
 where
     T: AuxArrayElement,
 {
@@ -1128,41 +1126,63 @@ where
     fn from_bytes(bytes: &'a [u8]) -> Self {
         Self::RawType(bytes)
     }
+
+    fn len(&self) -> usize {
+        match self {
+            StandardAuxArray::TargetType(a) => a.len(),
+            StandardAuxArray::RawType(a) => a.len() / std::mem::size_of::<T>(),
+        }
+    }
+
+    pub fn iter(&self) -> AuxArrayIterator<Self> {
+        AuxArrayIterator {
+            index: 0,
+            array: self,
+        }
+    }
 }
 
-impl<'a> AuxArrayTrait for AuxArray<'a, i8> {
+impl<'a> AuxArray for StandardAuxArray<'a, i8> {
     type Type = i8;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
-                if index > (*v).len() {
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
+                if index >= (*v).len() {
                     return None;
                 }
                 std::io::Cursor::new(&(*v)[index..][..1]).read_i8().ok()
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, u8> {
+impl<'a> AuxArray for StandardAuxArray<'a, u8> {
     type Type = u8;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => (*v).get(index).copied(),
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => (*v).get(index).copied(),
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, i16> {
+impl<'a> AuxArray for StandardAuxArray<'a, i16> {
     type Type = i16;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<i16>();
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
+                let type_size = std::mem::size_of::<Self::Type>();
                 if index * type_size + type_size > (*v).len() {
                     return None;
                 }
@@ -1172,14 +1192,18 @@ impl<'a> AuxArrayTrait for AuxArray<'a, i16> {
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, u16> {
+impl<'a> AuxArray for StandardAuxArray<'a, u16> {
     type Type = u16;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
                 let type_size = std::mem::size_of::<u16>();
                 if index * type_size + type_size > (*v).len() {
                     return None;
@@ -1190,14 +1214,18 @@ impl<'a> AuxArrayTrait for AuxArray<'a, u16> {
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, i32> {
+impl<'a> AuxArray for StandardAuxArray<'a, i32> {
     type Type = i32;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
                 let type_size = std::mem::size_of::<i32>();
                 if index * type_size + type_size > (*v).len() {
                     return None;
@@ -1208,14 +1236,18 @@ impl<'a> AuxArrayTrait for AuxArray<'a, i32> {
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, u32> {
+impl<'a> AuxArray for StandardAuxArray<'a, u32> {
     type Type = u32;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
                 let type_size = std::mem::size_of::<u32>();
                 if index * type_size + type_size > (*v).len() {
                     return None;
@@ -1226,14 +1258,18 @@ impl<'a> AuxArrayTrait for AuxArray<'a, u32> {
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
-impl<'a> AuxArrayTrait for AuxArray<'a, f32> {
+impl<'a> AuxArray for StandardAuxArray<'a, f32> {
     type Type = f32;
 
     fn get(&self, index: usize) -> Option<Self::Type> {
         match self {
-            AuxArray::TargetType(v) => (*v).get(index).copied(),
-            AuxArray::RawType(v) => {
+            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
+            StandardAuxArray::RawType(v) => {
                 let type_size = std::mem::size_of::<f32>();
                 if index * type_size + type_size > (*v).len() {
                     return None;
@@ -1244,16 +1280,20 @@ impl<'a> AuxArrayTrait for AuxArray<'a, f32> {
             }
         }
     }
+
+    fn len(&self) -> usize {
+        self.len()
+    }
 }
 
-pub struct AuxArrayIterator<T> {
+pub struct AuxArrayIterator<'a, T> {
     index: usize,
-    array: T,
+    array: &'a T,
 }
 
-impl<T> Iterator for AuxArrayIterator<T>
+impl<'a, T> Iterator for AuxArrayIterator<'a, T>
 where
-    T: AuxArrayTrait,
+    T: AuxArray,
 {
     type Item = T::Type;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1262,10 +1302,10 @@ where
         value
     }
 
-    // fn size_hint(&self) -> (usize, Option<usize>) {
-    //     let array_length = self.array.0.len() / std::mem::size_of::<T>() - self.index;
-    //     (array_length, Some(array_length))
-    // }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let array_length = self.array.len() - self.index;
+        (array_length, Some(array_length))
+    }
 }
 
 static DECODE_BASE: &[u8] = b"=ACMGRSVTWYHKDBN";

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1408,6 +1408,7 @@ where
 }
 
 /// Encapsulates slice of target type.
+#[doc(hidden)]
 #[derive(Debug, PartialEq)]
 pub struct AuxArrayTargetType<'a, T> {
     slice: &'a [T],
@@ -1427,6 +1428,7 @@ where
 }
 
 /// Encapsulates slice of raw bytes to prevent it from being accidentally accessed.
+#[doc(hidden)]
 #[derive(Debug, PartialEq)]
 pub struct AuxArrayRawLeBytes<'a, T> {
     slice: &'a [u8],

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -6,6 +6,7 @@
 use std::convert::TryFrom;
 use std::ffi;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem::{size_of, MaybeUninit};
 use std::ops;
 use std::rc::Rc;
@@ -847,17 +848,11 @@ impl AuxArrayElement for i32 {}
 impl AuxArrayElement for u32 {}
 impl AuxArrayElement for f32 {}
 
-enum AuxArrayDataType<'a, T> {
-    TargetType(&'a [T]),
-    RawBytes(&'a [u8]),
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct AuxArray<'a, T: AuxArrayElement> {
-    array: AuxArrayDataType<'a, T>,
+    data_type: PhantomData<T>,
+    array: &'a [u8],
 }
-
-impl<'a, T> AuxArray<'a, T> where T: AuxArrayElement {}
 
 static DECODE_BASE: &[u8] = b"=ACMGRSVTWYHKDBN";
 static ENCODE_BASE: [u8; 256] = [

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -15,6 +15,7 @@ use std::str;
 use std::str::FromStr;
 use std::u32;
 
+use byteorder::{ByteOrder, LittleEndian};
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -842,6 +843,66 @@ unsafe impl<'a> Sync for Aux<'a> {}
 pub struct AuxArray<'a, T: AuxArrayElement> {
     data_type: PhantomData<T>,
     array: &'a [u8],
+}
+
+impl<'a> AuxArray<'a, i8> {
+    pub fn get(&self, index: usize) -> i8 {
+        let i8_size = std::mem::size_of::<i8>();
+        unsafe {
+            slice::from_raw_parts(
+                self.array[index * std::i8_size..][..1]
+                    .as_ptr()
+                    .cast::<i8>(),
+                i8_size,
+            )
+        }
+        [0]
+    }
+}
+impl<'a> AuxArray<'a, u8> {
+    pub fn get(&self, index: usize) -> u8 {
+        self.array[index * std::mem::size_of::<u8>()]
+    }
+}
+impl<'a> AuxArray<'a, i16> {
+    pub fn get(&self, index: usize) -> i16 {
+        LittleEndian::read_i16(&self.array[index * std::mem::size_of::<i16>()..])
+    }
+}
+impl<'a> AuxArray<'a, u16> {
+    pub fn get(&self, index: usize) -> u16 {
+        LittleEndian::read_u16(&self.array[index * std::mem::size_of::<u16>()..])
+    }
+}
+impl<'a> AuxArray<'a, i32> {
+    pub fn get(&self, index: usize) -> i32 {
+        LittleEndian::read_i32(&self.array[index * std::mem::size_of::<i32>()..])
+    }
+}
+impl<'a> AuxArray<'a, u32> {
+    pub fn get(&self, index: usize) -> u32 {
+        LittleEndian::read_u32(&self.array[index * std::mem::size_of::<u32>()..])
+    }
+}
+impl<'a> AuxArray<'a, i64> {
+    pub fn get(&self, index: usize) -> i64 {
+        LittleEndian::read_i64(&self.array[index * std::mem::size_of::<i64>()..])
+    }
+}
+impl<'a> AuxArray<'a, u64> {
+    pub fn get(&self, index: usize) -> u64 {
+        LittleEndian::read_u64(&self.array[index * std::mem::size_of::<u64>()..])
+    }
+}
+impl<'a> AuxArray<'a, f32> {
+    pub fn get(&self, index: usize) -> f32 {
+        LittleEndian::read_f32(&self.array[index * std::mem::size_of::<f32>()..])
+    }
+}
+impl<'a> AuxArray<'a, f64> {
+    pub fn get(&self, index: usize) -> f64 {
+        LittleEndian::read_f64(&self.array[index * std::mem::size_of::<f64>()..])
+    }
 }
 
 static DECODE_BASE: &[u8] = b"=ACMGRSVTWYHKDBN";

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -754,8 +754,8 @@ impl Record {
     ///
     /// When an error occurs, the `Err` variant will be returned
     /// and the iterator will not be able to advance anymore.
-    pub fn aux_iter(&self) -> AuxIterator {
-        AuxIterator {
+    pub fn aux_iter(&self) -> AuxIter {
+        AuxIter {
             // In order to get to the aux data section of a `bam::Record`
             // we need to skip fields in front of it
             aux: &self.data()[
@@ -1394,8 +1394,8 @@ where
     }
 
     /// Returns an iterator over the array.
-    pub fn iter(&self) -> AuxArrayIterator<T> {
-        AuxArrayIterator {
+    pub fn iter(&self) -> AuxArrayIter<T> {
+        AuxArrayIter {
             index: 0,
             array: self,
         }
@@ -1413,12 +1413,12 @@ where
 /// Aux array iterator
 ///
 /// This struct is created by the [`AuxArray::iter`] method.
-pub struct AuxArrayIterator<'a, T> {
+pub struct AuxArrayIter<'a, T> {
     index: usize,
     array: &'a AuxArray<'a, T>,
 }
 
-impl<T> Iterator for AuxArrayIterator<'_, T>
+impl<T> Iterator for AuxArrayIter<'_, T>
 where
     T: AuxArrayElement,
 {
@@ -1441,11 +1441,11 @@ where
 ///
 /// When an error occurs, the `Err` variant will be returned
 /// and the iterator will not be able to advance anymore.
-pub struct AuxIterator<'a> {
+pub struct AuxIter<'a> {
     aux: &'a [u8],
 }
 
-impl<'a> Iterator for AuxIterator<'a> {
+impl<'a> Iterator for AuxIter<'a> {
     type Item = Result<(&'a [u8], Aux<'a>)>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -698,43 +698,49 @@ impl Record {
 
         match tag_type {
             b'c' => Some((
-                Aux::ArrayI8(StandardAuxArray::<'a, i8>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length),
-                )),
+                Aux::ArrayI8(AuxArray::<'a, i8>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length,
+                ))),
                 length,
             )),
             b'C' => Some((
-                Aux::ArrayU8(StandardAuxArray::<'a, u8>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length),
-                )),
+                Aux::ArrayU8(AuxArray::<'a, u8>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length,
+                ))),
                 length,
             )),
             b's' => Some((
-                Aux::ArrayI16(StandardAuxArray::<'a, i16>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<i16>()),
-                )),
+                Aux::ArrayI16(AuxArray::<'a, i16>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length * size_of::<i16>(),
+                ))),
                 length,
             )),
             b'S' => Some((
-                Aux::ArrayU16(StandardAuxArray::<'a, u16>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<u16>()),
-                )),
+                Aux::ArrayU16(AuxArray::<'a, u16>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length * size_of::<u16>(),
+                ))),
                 length,
             )),
             b'i' => Some((
-                Aux::ArrayI32(StandardAuxArray::<'a, i32>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<i32>()),
-                )),
+                Aux::ArrayI32(AuxArray::<'a, i32>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length * size_of::<i32>(),
+                ))),
                 length,
             )),
             b'I' => Some((
-                Aux::ArrayU32(StandardAuxArray::<'a, u32>::from_bytes(
-                    slice::from_raw_parts(aux.offset(OFFSET), length * size_of::<u32>()),
-                )),
+                Aux::ArrayU32(AuxArray::<'a, u32>::from_bytes(slice::from_raw_parts(
+                    aux.offset(OFFSET),
+                    length * size_of::<u32>(),
+                ))),
                 length,
             )),
             b'f' => Some((
-                Aux::ArrayFloat(StandardAuxArray::<f32>::from_bytes(slice::from_raw_parts(
+                Aux::ArrayFloat(AuxArray::<f32>::from_bytes(slice::from_raw_parts(
                     aux.offset(OFFSET),
                     length * size_of::<f32>(),
                 ))),
@@ -834,49 +840,49 @@ impl Record {
                     )
                 }
                 // Not sure it's safe casting an immutable slice to a mutable pointer here
-                Aux::ArrayI8(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'c',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU8(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'C',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayI16(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b's',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU16(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'S',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayI32(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayI32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'i',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayU32(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayU32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'I',
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                Aux::ArrayFloat(StandardAuxArray::TargetType(v)) => htslib::bam_aux_update_array(
+                Aux::ArrayFloat(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'f',
@@ -1071,231 +1077,126 @@ pub enum Aux<'a> {
     Double(f64), // Not part of specs but implemented in `htslib`
     String(&'a str),
     HexByteArray(&'a str),
-    ArrayI8(StandardAuxArray<'a, i8>),
-    ArrayU8(StandardAuxArray<'a, u8>),
-    ArrayI16(StandardAuxArray<'a, i16>),
-    ArrayU16(StandardAuxArray<'a, u16>),
-    ArrayI32(StandardAuxArray<'a, i32>),
-    ArrayU32(StandardAuxArray<'a, u32>),
-    ArrayFloat(StandardAuxArray<'a, f32>),
+    ArrayI8(AuxArray<'a, i8>),
+    ArrayU8(AuxArray<'a, u8>),
+    ArrayI16(AuxArray<'a, i16>),
+    ArrayU16(AuxArray<'a, u16>),
+    ArrayI32(AuxArray<'a, i32>),
+    ArrayU32(AuxArray<'a, u32>),
+    ArrayFloat(AuxArray<'a, f32>),
 }
 
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
 
-#[derive(Debug, PartialEq)]
-pub enum StandardAuxArray<'a, T> {
-    TargetType(&'a [T]),
-    RawType(&'a [u8]),
+// Specify types that can be used in aux arrays
+pub trait AuxArrayElement: Copy {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self>;
 }
 
-// Specify types which can be used in aux arrays to restrict From impls
-pub trait AuxArrayElement {}
-impl AuxArrayElement for i8 {}
-impl AuxArrayElement for u8 {}
-impl AuxArrayElement for i16 {}
-impl AuxArrayElement for u16 {}
-impl AuxArrayElement for i32 {}
-impl AuxArrayElement for u32 {}
-impl AuxArrayElement for f32 {}
+impl AuxArrayElement for i8 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_i8().ok()
+    }
+}
+impl AuxArrayElement for u8 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_u8().ok()
+    }
+}
+impl AuxArrayElement for i16 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_i16::<LittleEndian>().ok()
+    }
+}
+impl AuxArrayElement for u16 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_u16::<LittleEndian>().ok()
+    }
+}
+impl AuxArrayElement for i32 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_i32::<LittleEndian>().ok()
+    }
+}
+impl AuxArrayElement for u32 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_u32::<LittleEndian>().ok()
+    }
+}
+impl AuxArrayElement for f32 {
+    fn from_le_bytes(bytes: &[u8]) -> Option<Self> {
+        std::io::Cursor::new(bytes).read_f32::<LittleEndian>().ok()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum AuxArray<'a, T> {
+    TargetType(&'a [T]),
+    RawLeBytes(&'a [u8]),
+}
 
 /// Create AuxArrays from slices of allowed target types
-impl<'a, T> From<&'a [T]> for StandardAuxArray<'a, T>
+impl<'a, T> From<&'a [T]> for AuxArray<'a, T>
 where
     T: AuxArrayElement,
 {
     fn from(src: &'a [T]) -> Self {
-        StandardAuxArray::TargetType(src)
+        AuxArray::TargetType(src)
     }
 }
 
-pub trait AuxArray {
-    type Type;
-    fn get(&self, index: usize) -> Option<Self::Type>;
-    fn len(&self) -> usize;
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-}
-
-impl<'a, T> StandardAuxArray<'a, T>
+impl<'a, T> AuxArray<'a, T>
 where
     T: AuxArrayElement,
 {
-    /// Create AuxArrays from raw byte slices of bam::Record
-    fn from_bytes(bytes: &'a [u8]) -> Self {
-        Self::RawType(bytes)
-    }
-
-    fn len(&self) -> usize {
+    pub fn get(&self, index: usize) -> Option<T> {
         match self {
-            StandardAuxArray::TargetType(a) => a.len(),
-            StandardAuxArray::RawType(a) => a.len() / std::mem::size_of::<T>(),
+            AuxArray::TargetType(v) => v.get(index).copied(),
+            AuxArray::RawLeBytes(v) => {
+                let type_size = std::mem::size_of::<T>();
+                if index * type_size + type_size > v.len() {
+                    return None;
+                }
+                T::from_le_bytes(&v[index * type_size..][..type_size])
+            }
         }
     }
 
-    pub fn iter(&self) -> AuxArrayIterator<Self> {
+    pub fn len(&self) -> usize {
+        match self {
+            AuxArray::TargetType(a) => a.len(),
+            AuxArray::RawLeBytes(a) => a.len() / std::mem::size_of::<T>(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn iter(&self) -> AuxArrayIterator<T> {
         AuxArrayIterator {
             index: 0,
             array: self,
         }
     }
-}
 
-impl<'a> AuxArray for StandardAuxArray<'a, i8> {
-    type Type = i8;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                if index >= (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index..][..1]).read_i8().ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, u8> {
-    type Type = u8;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => (*v).get(index).copied(),
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, i16> {
-    type Type = i16;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<Self::Type>();
-                if index * type_size + type_size > (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index * type_size..][..type_size])
-                    .read_i16::<LittleEndian>()
-                    .ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, u16> {
-    type Type = u16;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<u16>();
-                if index * type_size + type_size > (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index * type_size..][..type_size])
-                    .read_u16::<LittleEndian>()
-                    .ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, i32> {
-    type Type = i32;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<i32>();
-                if index * type_size + type_size > (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index * type_size..][..type_size])
-                    .read_i32::<LittleEndian>()
-                    .ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, u32> {
-    type Type = u32;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<u32>();
-                if index * type_size + type_size > (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index * type_size..][..type_size])
-                    .read_u32::<LittleEndian>()
-                    .ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-impl<'a> AuxArray for StandardAuxArray<'a, f32> {
-    type Type = f32;
-
-    fn get(&self, index: usize) -> Option<Self::Type> {
-        match self {
-            StandardAuxArray::TargetType(v) => (*v).get(index).copied(),
-            StandardAuxArray::RawType(v) => {
-                let type_size = std::mem::size_of::<f32>();
-                if index * type_size + type_size > (*v).len() {
-                    return None;
-                }
-                std::io::Cursor::new(&(*v)[index * type_size..][..type_size])
-                    .read_f32::<LittleEndian>()
-                    .ok()
-            }
-        }
-    }
-
-    fn len(&self) -> usize {
-        self.len()
+    /// Create AuxArrays from raw byte slices of bam::Record
+    fn from_bytes(bytes: &'a [u8]) -> Self {
+        Self::RawLeBytes(bytes)
     }
 }
 
 pub struct AuxArrayIterator<'a, T> {
     index: usize,
-    array: &'a T,
+    array: &'a AuxArray<'a, T>,
 }
 
-impl<'a, T> Iterator for AuxArrayIterator<'a, T>
+impl<T> Iterator for AuxArrayIterator<'_, T>
 where
-    T: AuxArray,
+    T: AuxArrayElement,
 {
-    type Item = T::Type;
+    type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
         let value = self.array.get(self.index);
         self.index += 1;

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -597,81 +597,81 @@ impl Record {
         } else {
             match *aux {
                 b'A' => {
-                    let length = size_of::<u8>();
-                    Some((Aux::Char(*aux.offset(OFFSET)), length))
+                    let type_size = size_of::<u8>();
+                    Some((Aux::Char(*aux.offset(OFFSET)), type_size))
                 }
                 b'c' => {
-                    let length = size_of::<i8>();
-                    Some((Aux::I8(*aux.offset(OFFSET).cast::<i8>()), length))
+                    let type_size = size_of::<i8>();
+                    Some((Aux::I8(*aux.offset(OFFSET).cast::<i8>()), type_size))
                 }
                 b'C' => {
-                    let length = size_of::<u8>();
-                    Some((Aux::U8(*aux.offset(OFFSET)), length))
+                    let type_size = size_of::<u8>();
+                    Some((Aux::U8(*aux.offset(OFFSET)), type_size))
                 }
                 b's' => {
-                    let length = size_of::<i16>();
+                    let type_size = size_of::<i16>();
                     Some((
                         Aux::I16(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_i16::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'S' => {
-                    let length = size_of::<u16>();
+                    let type_size = size_of::<u16>();
                     Some((
                         Aux::U16(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_u16::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'i' => {
-                    let length = size_of::<i32>();
+                    let type_size = size_of::<i32>();
                     Some((
                         Aux::I32(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_i32::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'I' => {
-                    let length = size_of::<u32>();
+                    let type_size = size_of::<u32>();
                     Some((
                         Aux::U32(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_u32::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'f' => {
-                    let length = size_of::<f32>();
+                    let type_size = size_of::<f32>();
                     Some((
                         Aux::Float(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_f32::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'd' => {
-                    let length = size_of::<f64>();
+                    let type_size = size_of::<f64>();
                     Some((
                         Aux::Double(
-                            slice::from_raw_parts(aux.offset(OFFSET), length)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_f64::<LittleEndian>()
                                 .ok()?,
                         ),
-                        length,
+                        type_size,
                     ))
                 }
                 b'Z' | b'H' => {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -990,8 +990,8 @@ impl Record {
     }
 
     // Delete auxiliary tag.
-    pub fn remove_aux(&mut self, tag: &[u8]) -> bool {
-        let c_str = ffi::CString::new(tag).unwrap();
+    pub fn remove_aux(&mut self, tag: &[u8]) -> Result<()> {
+        let c_str = ffi::CString::new(tag).map_err(|_| Error::BamAuxStringError)?;
         let aux = unsafe {
             htslib::bam_aux_get(
                 &self.inner as *const htslib::bam1_t,
@@ -1000,10 +1000,10 @@ impl Record {
         };
         unsafe {
             if aux.is_null() {
-                false
+                Err(Error::BamAuxTagNotFound)
             } else {
                 htslib::bam_aux_del(self.inner_ptr_mut(), aux);
-                true
+                Ok(())
             }
         }
     }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -839,54 +839,55 @@ impl Record {
                         c_str.as_ptr() as *mut u8,
                     )
                 }
+                // Not sure it's safe casting an immutable slice to a mutable pointer here
                 Aux::ArrayI8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'c',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayU8(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'C',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayI16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b's',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayU16(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'S',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayI32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'i',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayU32(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'I',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 Aux::ArrayFloat(AuxArray::TargetType(v)) => htslib::bam_aux_update_array(
                     self.inner_ptr_mut(),
                     ctag,
                     b'f',
                     v.len() as u32,
-                    v.as_mut_ptr() as *mut ::libc::c_void,
+                    v.as_ptr() as *mut ::libc::c_void,
                 ),
                 _ => 0,
             }
@@ -1090,7 +1091,7 @@ unsafe impl<'a> Sync for Aux<'a> {}
 
 #[derive(Debug, PartialEq)]
 pub enum AuxArray<'a, T> {
-    TargetType(&'a mut [T]),
+    TargetType(&'a [T]),
     RawType(&'a [u8]),
 }
 
@@ -1105,11 +1106,11 @@ impl AuxArrayType for u32 {}
 impl AuxArrayType for f32 {}
 
 /// Create AuxArrays from slices of allowed target types
-impl<'a, T> From<&'a mut [T]> for AuxArray<'a, T>
+impl<'a, T> From<&'a [T]> for AuxArray<'a, T>
 where
     T: AuxArrayType,
 {
-    fn from(src: &'a mut [T]) -> Self {
+    fn from(src: &'a [T]) -> Self {
         AuxArray::TargetType(src)
     }
 }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1207,13 +1207,14 @@ pub enum AuxArray<'a, T> {
     RawLeBytes(&'a [u8]),
 }
 
-/// Create AuxArrays from slices of allowed target types
-impl<'a, T> From<&'a [T]> for AuxArray<'a, T>
+/// Create AuxArrays from slices of allowed target types.
+impl<'a, I, T> From<&'a T> for AuxArray<'a, I>
 where
-    T: AuxArrayElement,
+    I: AuxArrayElement,
+    T: AsRef<[I]> + ?Sized,
 {
-    fn from(src: &'a [T]) -> Self {
-        AuxArray::TargetType(src)
+    fn from(src: &'a T) -> Self {
+        AuxArray::TargetType(src.as_ref())
     }
 }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -752,7 +752,8 @@ impl Record {
 
     /// Returns an iterator over the auxiliary fields of the record.
     ///
-    /// The iteration gets aborted as soon as an error occurs
+    /// When an error occurs, the `Err` variant will be returned
+    /// and the iterator will not be able to advance anymore.
     pub fn aux_iter(&self) -> AuxIterator {
         AuxIterator {
             // In order to get to the aux data section of a `bam::Record`
@@ -1153,7 +1154,7 @@ impl genome::AbstractInterval for Record {
     }
 }
 
-/// Auxiliary record data.
+/// Auxiliary record data
 ///
 /// # Examples
 ///
@@ -1228,7 +1229,7 @@ pub enum Aux<'a> {
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
 
-// Specify types that can be used in aux arrays
+/// Types that can be used in aux arrays.
 pub trait AuxArrayElement: Copy {
     fn from_le_bytes(bytes: &[u8]) -> Option<Self>;
 }
@@ -1311,7 +1312,7 @@ pub enum AuxArray<'a, T> {
     RawLeBytes(AuxArrayRawLeBytes<'a, T>),
 }
 
-/// Encapsulates slice of target type
+/// Encapsulates slice of target type.
 #[derive(Debug, PartialEq)]
 pub struct AuxArrayTargetType<'a, T> {
     slice: &'a [T],
@@ -1330,7 +1331,7 @@ where
     }
 }
 
-/// Encapsulates slice of raw bytes to prevent it from being accidentally accessed
+/// Encapsulates slice of raw bytes to prevent it from being accidentally accessed.
 #[derive(Debug, PartialEq)]
 pub struct AuxArrayRawLeBytes<'a, T> {
     slice: &'a [u8],
@@ -1400,7 +1401,7 @@ where
         }
     }
 
-    /// Create AuxArrays from raw byte slices borrowed from `bam::Record`
+    /// Create AuxArrays from raw byte slices borrowed from `bam::Record`.
     fn from_bytes(bytes: &'a [u8]) -> Self {
         Self::RawLeBytes(AuxArrayRawLeBytes {
             slice: bytes,
@@ -1434,6 +1435,12 @@ where
     }
 }
 
+/// Auxiliary data iterator
+///
+/// This struct is created by the [`Record::aux_iter`] method.
+///
+/// When an error occurs, the `Err` variant will be returned
+/// and the iterator will not be able to advance anymore.
 pub struct AuxIterator<'a> {
     aux: &'a [u8],
 }

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -582,11 +582,7 @@ impl Record {
                 c_str.as_ptr() as *mut i8,
             )
         };
-        if aux.is_null() {
-            None
-        } else {
-            unsafe { Self::read_aux_field(aux).map(|(aux_field, _length)| aux_field) }
-        }
+        unsafe { Self::read_aux_field(aux).map(|(aux_field, _length)| aux_field) }
     }
 
     unsafe fn read_aux_field<'a>(aux: *const u8) -> Option<(Aux<'a>, usize)> {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -834,37 +834,6 @@ pub enum Aux<'a> {
     ArrayFloat(AuxArray<'a, f32>),
 }
 
-impl<'a> Aux<'a> {
-    /// Get string from aux data (panics if not a string).
-    pub fn string(&self) -> &'a [u8] {
-        match *self {
-            Aux::String(x) => x,
-            _ => panic!("not a string"),
-        }
-    }
-
-    pub fn float(&self) -> f64 {
-        match *self {
-            Aux::Float(x) => x,
-            _ => panic!("not a float"),
-        }
-    }
-
-    pub fn integer(&self) -> i64 {
-        match *self {
-            Aux::Integer(x) => x,
-            _ => panic!("not an integer"),
-        }
-    }
-
-    pub fn char(&self) -> u8 {
-        match *self {
-            Aux::Char(x) => x,
-            _ => panic!("not a character"),
-        }
-    }
-}
-
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -848,7 +848,7 @@ impl Record {
                     [v].as_mut_ptr() as *mut u8,
                 ),
                 Aux::String(v) => {
-                    let c_str = ffi::CString::new(v).unwrap();
+                    let c_str = ffi::CString::new(v).map_err(|_| Error::BamAuxStringError)?;
                     htslib::bam_aux_append(
                         self.inner_ptr_mut(),
                         ctag,
@@ -858,7 +858,7 @@ impl Record {
                     )
                 }
                 Aux::HexByteArray(v) => {
-                    let c_str = ffi::CString::new(v).unwrap();
+                    let c_str = ffi::CString::new(v).map_err(|_| Error::BamAuxStringError)?;
                     htslib::bam_aux_append(
                         self.inner_ptr_mut(),
                         ctag,

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -591,6 +591,7 @@ impl Record {
 
     unsafe fn read_aux_field<'a>(aux: *const u8) -> Option<(Aux<'a>, usize)> {
         const OFFSET: isize = 1;
+
         if aux.is_null() {
             None
         } else {
@@ -750,7 +751,7 @@ impl Record {
     }
 
     /// Add auxiliary data.
-    pub fn push_aux<T>(&mut self, tag: &[u8], value: Aux<'_>) {
+    pub fn push_aux(&mut self, tag: &[u8], value: Aux<'_>) {
         let ctag = tag.as_ptr() as *mut i8;
         let ret = unsafe {
             match value {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -696,6 +696,7 @@ impl Record {
             .read_u32::<LittleEndian>()
             .map_err(|_| Error::BamAuxParsingError)? as usize;
 
+        // Return tuples of an `Aux` enum and the length of data + metadata in bytes
         match tag_type {
             b'c' => Ok((
                 Aux::ArrayI8(AuxArray::<'a, i8>::from_bytes(slice::from_raw_parts(
@@ -1156,6 +1157,10 @@ impl genome::AbstractInterval for Record {
 
 /// Auxiliary record data
 ///
+/// The specification allows a wide range of types to be stored as an auxiliary data field of a BAM record.
+///
+/// Please note that the [`Aux::Double`] variant is _not_ part of the specification, but it is supported by `htslib`.
+///
 /// # Examples
 ///
 /// ```
@@ -1272,23 +1277,30 @@ impl AuxArrayElement for f32 {
 
 /// Provides access to aux arrays.
 ///
-/// Holds either a slice of a supported target type to be stored in an aux field
-/// or a raw byte slice pointing to record data.
+/// Provides methods to either retrieve single elements or an iterator over the
+/// array.
 ///
-/// Provides methods to either retrieve single elements or an iterator over all
-/// values in the array.
+/// This type is used for wrapping both, array data that was read from a
+/// BAM record and slices of data that are going to be stored in one.
+///
+/// In order to be able to add an `AuxArray` field to a BAM record, `AuxArray`s
+/// can be constructed via the `From` trait which is implemented for all
+/// supported types (see [`AuxArrayElement`] for a list).
 ///
 /// # Examples
 ///
 /// ```
-/// use rust_htslib::{bam, bam::record::{Aux, AuxArray}};
+/// use rust_htslib::{
+///     bam,
+///     bam::record::{Aux, AuxArray},
+/// };
 ///
 /// //Set up BAM record
 /// let bam_header = bam::Header::new();
 /// let mut record = bam::Record::from_sam(
-///         &mut bam::HeaderView::from_header(&bam_header),
-///         "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
-///     ).unwrap();
+///     &mut bam::HeaderView::from_header(&bam_header),
+///     "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
+/// ).unwrap();
 ///
 /// let data = vec![0.4, 0.3, 0.2, 0.1];
 /// let slice_of_data = &data;

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1451,6 +1451,10 @@ where
 ///
 /// This struct is created by the [`Record::aux_iter`] method.
 ///
+/// This iterator returns `Result`s that wrap tuples containing
+/// a slice which represents the two-byte tag (`&[u8; 2]`) as
+/// well as an `Aux` enum that wraps the associated value.
+///
 /// When an error occurs, the `Err` variant will be returned
 /// and the iterator will not be able to advance anymore.
 pub struct AuxIter<'a> {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1323,49 +1323,6 @@ pub enum AuxArray<'a, T> {
     RawLeBytes(AuxArrayRawLeBytes<'a, T>),
 }
 
-/// Encapsulates slice of target type.
-#[derive(Debug, PartialEq)]
-pub struct AuxArrayTargetType<'a, T> {
-    slice: &'a [T],
-}
-
-impl<'a, T> AuxArrayTargetType<'a, T>
-where
-    T: AuxArrayElement,
-{
-    fn get(&self, index: usize) -> Option<T> {
-        self.slice.get(index).copied()
-    }
-
-    fn len(&self) -> usize {
-        self.slice.len()
-    }
-}
-
-/// Encapsulates slice of raw bytes to prevent it from being accidentally accessed.
-#[derive(Debug, PartialEq)]
-pub struct AuxArrayRawLeBytes<'a, T> {
-    slice: &'a [u8],
-    phantom_data: PhantomData<T>,
-}
-
-impl<'a, T> AuxArrayRawLeBytes<'a, T>
-where
-    T: AuxArrayElement,
-{
-    fn get(&self, index: usize) -> Option<T> {
-        let type_size = std::mem::size_of::<T>();
-        if index * type_size + type_size > self.slice.len() {
-            return None;
-        }
-        T::from_le_bytes(&self.slice[index * type_size..][..type_size])
-    }
-
-    fn len(&self) -> usize {
-        self.slice.len() / std::mem::size_of::<T>()
-    }
-}
-
 /// Create AuxArrays from slices of allowed target types.
 impl<'a, I, T> From<&'a T> for AuxArray<'a, I>
 where
@@ -1418,6 +1375,49 @@ where
             slice: bytes,
             phantom_data: PhantomData,
         })
+    }
+}
+
+/// Encapsulates slice of target type.
+#[derive(Debug, PartialEq)]
+pub struct AuxArrayTargetType<'a, T> {
+    slice: &'a [T],
+}
+
+impl<'a, T> AuxArrayTargetType<'a, T>
+where
+    T: AuxArrayElement,
+{
+    fn get(&self, index: usize) -> Option<T> {
+        self.slice.get(index).copied()
+    }
+
+    fn len(&self) -> usize {
+        self.slice.len()
+    }
+}
+
+/// Encapsulates slice of raw bytes to prevent it from being accidentally accessed.
+#[derive(Debug, PartialEq)]
+pub struct AuxArrayRawLeBytes<'a, T> {
+    slice: &'a [u8],
+    phantom_data: PhantomData<T>,
+}
+
+impl<'a, T> AuxArrayRawLeBytes<'a, T>
+where
+    T: AuxArrayElement,
+{
+    fn get(&self, index: usize) -> Option<T> {
+        let type_size = std::mem::size_of::<T>();
+        if index * type_size + type_size > self.slice.len() {
+            return None;
+        }
+        T::from_le_bytes(&self.slice[index * type_size..][..type_size])
+    }
+
+    fn len(&self) -> usize {
+        self.slice.len() / std::mem::size_of::<T>()
     }
 }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1317,10 +1317,25 @@ impl AuxArrayElement for f32 {
 ///     panic!("Could not read array data");
 /// }
 /// ```
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum AuxArray<'a, T> {
     TargetType(AuxArrayTargetType<'a, T>),
     RawLeBytes(AuxArrayRawLeBytes<'a, T>),
+}
+
+impl<T> PartialEq<AuxArray<'_, T>> for AuxArray<'_, T>
+where
+    T: AuxArrayElement + PartialEq,
+{
+    fn eq(&self, other: &AuxArray<'_, T>) -> bool {
+        use AuxArray::*;
+        match (self, other) {
+            (TargetType(v), TargetType(v_other)) => v == v_other,
+            (RawLeBytes(v), RawLeBytes(v_other)) => v == v_other,
+            (TargetType(_), RawLeBytes(_)) => self.iter().eq(other.iter()),
+            (RawLeBytes(_), TargetType(_)) => self.iter().eq(other.iter()),
+        }
+    }
 }
 
 /// Create AuxArrays from slices of allowed target types.

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -612,73 +612,72 @@ impl Record {
                     let type_size = size_of::<i16>();
                     Ok((
                         Aux::I16(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_i16::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'S' => {
                     let type_size = size_of::<u16>();
                     Ok((
                         Aux::U16(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_u16::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'i' => {
                     let type_size = size_of::<i32>();
                     Ok((
                         Aux::I32(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_i32::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'I' => {
                     let type_size = size_of::<u32>();
                     Ok((
                         Aux::U32(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_u32::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'f' => {
                     let type_size = size_of::<f32>();
                     Ok((
                         Aux::Float(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_f32::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'd' => {
                     let type_size = size_of::<f64>();
                     Ok((
                         Aux::Double(
-                            slice::from_raw_parts(aux.offset(OFFSET), type_size + 3)
+                            slice::from_raw_parts(aux.offset(OFFSET), type_size)
                                 .read_f64::<LittleEndian>()
                                 .map_err(|_| Error::BamAuxParsingError)?,
                         ),
-                        type_size,
+                        type_size + 3,
                     ))
                 }
                 b'Z' | b'H' => {
-                    let x = ffi::CStr::from_ptr(aux.offset(OFFSET).cast::<i8>())
-                        .to_str()
-                        .map_err(|_| Error::BamAuxParsingError)?;
-                    Ok((Aux::String(x), x.len() + 3))
+                    let c_str = ffi::CStr::from_ptr(aux.offset(OFFSET).cast::<i8>());
+                    let rust_str = c_str.to_str().map_err(|_| Error::BamAuxParsingError)?;
+                    Ok((Aux::String(rust_str), c_str.to_bytes_with_nul().len() + 3))
                 }
                 b'B' => Self::read_aux_array_types(aux),
                 _ => Err(Error::BamAuxUnknownType),

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -747,7 +747,7 @@ impl Record {
     }
 
     /// Add auxiliary data.
-    pub fn push_aux(&mut self, tag: &[u8], value: Aux<'_>) {
+    pub fn push_aux(&mut self, tag: &[u8], value: Aux<'_>) -> Result<()> {
         let ctag = tag.as_ptr() as *mut i8;
         let ret = unsafe {
             match value {
@@ -885,12 +885,14 @@ impl Record {
                     v.len() as u32,
                     v.as_ptr() as *mut ::libc::c_void,
                 ),
-                _ => 0,
+                _ => -1,
             }
         };
 
         if ret < 0 {
-            panic!("htslib ran out of memory in push_aux");
+            Err(Error::BamAux)
+        } else {
+            Ok(())
         }
     }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1096,19 +1096,19 @@ pub enum AuxArray<'a, T> {
 }
 
 // Specify types which can be used in aux arrays to restrict From impls
-pub trait AuxArrayType {}
-impl AuxArrayType for i8 {}
-impl AuxArrayType for u8 {}
-impl AuxArrayType for i16 {}
-impl AuxArrayType for u16 {}
-impl AuxArrayType for i32 {}
-impl AuxArrayType for u32 {}
-impl AuxArrayType for f32 {}
+pub trait AuxArrayElement {}
+impl AuxArrayElement for i8 {}
+impl AuxArrayElement for u8 {}
+impl AuxArrayElement for i16 {}
+impl AuxArrayElement for u16 {}
+impl AuxArrayElement for i32 {}
+impl AuxArrayElement for u32 {}
+impl AuxArrayElement for f32 {}
 
 /// Create AuxArrays from slices of allowed target types
 impl<'a, T> From<&'a [T]> for AuxArray<'a, T>
 where
-    T: AuxArrayType,
+    T: AuxArrayElement,
 {
     fn from(src: &'a [T]) -> Self {
         AuxArray::TargetType(src)
@@ -1117,7 +1117,7 @@ where
 
 impl<'a, T> AuxArray<'a, T>
 where
-    T: AuxArrayType,
+    T: AuxArrayElement,
 {
     /// Create AuxArrays from raw byte slices of bam::Record
     fn from_bytes(bytes: &'a [u8]) -> Self {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -6,6 +6,7 @@
 use std::convert::TryFrom;
 use std::ffi;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem::{size_of, MaybeUninit};
 use std::ops;
 use std::rc::Rc;
@@ -836,6 +837,22 @@ pub enum Aux<'a> {
 
 unsafe impl<'a> Send for Aux<'a> {}
 unsafe impl<'a> Sync for Aux<'a> {}
+
+pub trait AuxArrayElement: Copy {}
+
+impl AuxArrayElement for i8 {}
+impl AuxArrayElement for u8 {}
+impl AuxArrayElement for i16 {}
+impl AuxArrayElement for u16 {}
+impl AuxArrayElement for i32 {}
+impl AuxArrayElement for u32 {}
+impl AuxArrayElement for f32 {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AuxArray<'a, T: AuxArrayElement> {
+    data_type: PhantomData<T>,
+    array: &'a [u8],
+}
 
 static DECODE_BASE: &[u8] = b"=ACMGRSVTWYHKDBN";
 static ENCODE_BASE: [u8; 256] = [

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -812,12 +812,26 @@ impl genome::AbstractInterval for Record {
 }
 
 /// Auxiliary record data.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Aux<'a> {
-    Integer(i64),
-    String(&'a [u8]),
-    Float(f64),
     Char(u8),
+    I8(i8),
+    U8(u8),
+    I16(i16),
+    U16(u16),
+    I32(i32),
+    U32(u32),
+    Float(f32),
+    Double(f64), // Not part of specs but implemented in `htslib`
+    String(&'a str),
+    HexByteArray(&'a str),
+    ArrayI8(AuxArray<'a, i8>),
+    ArrayU8(AuxArray<'a, u8>),
+    ArrayI16(AuxArray<'a, i16>),
+    ArrayU16(AuxArray<'a, u16>),
+    ArrayI32(AuxArray<'a, i32>),
+    ArrayU32(AuxArray<'a, u32>),
+    ArrayFloat(AuxArray<'a, f32>),
 }
 
 impl<'a> Aux<'a> {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -70,8 +70,15 @@ pub enum Error {
     #[error("failed to create SAM/BAM/CRAM pileup")]
     BamPileup,
 
+    // Errors for BAM auxiliary fields
     #[error("failed to add aux field (out of memory?)")]
     BamAux,
+    #[error("failed to parse aux data")]
+    BamAuxParsingError,
+    #[error("the specified tag does could not be found")]
+    BamAuxTagNotFound,
+    #[error("data type of aux field is not known")]
+    BamAuxUnknownType,
     #[error("failed to add aux field, tag is already present")]
     BamAuxTagAlreadyPresent,
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,8 +69,11 @@ pub enum Error {
     BamBuildIndex,
     #[error("failed to create SAM/BAM/CRAM pileup")]
     BamPileup,
-    #[error("failed to add aux field")]
+
+    #[error("failed to add aux field (out of memory?)")]
     BamAux,
+    #[error("failed to add aux field, tag is already present")]
+    BamAuxTagAlreadyPresent,
 
     // Errors for BCF
     #[error("error allocating internal data structure for BCF/VCF reader (out of memory?)")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -69,6 +69,8 @@ pub enum Error {
     BamBuildIndex,
     #[error("failed to create SAM/BAM/CRAM pileup")]
     BamPileup,
+    #[error("failed to add aux field")]
+    BamAux,
 
     // Errors for BCF
     #[error("error allocating internal data structure for BCF/VCF reader (out of memory?)")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -73,6 +73,8 @@ pub enum Error {
     // Errors for BAM auxiliary fields
     #[error("failed to add aux field (out of memory?)")]
     BamAux,
+    #[error("provided string contains internal 0 byte(s)")]
+    BamAuxStringError,
     #[error("failed to parse aux data")]
     BamAuxParsingError,
     #[error("the specified tag does could not be found")]


### PR DESCRIPTION
Hey all!

This is the successor to #170 as well as an attempt to fix #209 and #227. Apologies for taking so long.

It's a quite large PR but its goals are intertwined:
- Support for all and fixes for some scalar auxiliary field types
- Support for auxiliary arrays
- Support for iterating over all auxiliary fields of a `bam::record::Record`

Unfortunately, as discussed previously over at #170, we can't solely rely on `htslib` functions for interacting with auxiliary fields. For example, `htslib` returns all integer values as `i64`, so this PR instead uses the `byteorder` crate to read directly from raw byte arrays of `bam::record::Record`s in some places in order to be able to allow fine-grained control over types. 

`AuxArray`s are implemented as an enum that either holds a slice of bytes borrowed from a `Record` or a slice of a "target type" supported by the BAM standard. The latter variant can conveniently by constructed via `From` impls for slices of all supported target types. The inner slice is kept private in order to hide this implementation detail and--more importantly--to only allow type safe access. Also, both variants of `PartialEq` can be compared to each other using the `PartialEq` impl.
The values can be accessed via the `get` or `iter` methods which yield single values or iterators, respectively.

Access to all auxiliary fields of a BAM record is possible now (realized via the `aux_iter()` method on `Record`s and the corresponding `Iterator` impl).

The added API docs hopefully do a better job explaining these changes. You can also find some examples in there.

A couple of things I'm not sure about:
- I haven't been particularly hesitant from making API changes (e.g. by introducing `Result` return types to represent possible errors)
- A couple (lot?) of variants got added to the internal `Error` enum
- I'm not sure if casting an immutable pointer to a *mut void is sound (e.g. here: https://github.com/jch-13/rust-htslib/blob/4d6e0a1dfb4256a3c80903fe28b38829d3536e5e/src/bam/record.rs#L890). `htslib` does not mutate the data behind it, though. Also, this pattern can be found in other places of the library code. 
- Some repetition could perhaps be replaced with a macro
- The `update_...` class of functions (like https://github.com/samtools/htslib/blob/f39dae751dae8c1abf8477074c5fbaea66d229df/htslib/sam.h#L1769) is not (yet?)  implemented
- Commits should probably be squashed


Please let me know what you think about this. Thank you! :)