### PR TITLE
Potential speed up for CigarString::try_from(&str)

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1159,7 +1159,19 @@ impl TryFrom<&str> for CigarString {
                         });
                     }
                 }
-                "S" => Cigar::SoftClip(n),
+                "S" => {
+                    if i == 0
+                        || j+1 == text_len
+                        || &text[i-1..i] == "H"
+                        || &text[j+1..].chars().all(|c| c.is_ascii_digit() || c == "H") {
+                        Cigar::SoftClip(n)
+                    } else {
+                        return Err(Error::BamParseCigar {
+                        msg: "Soft clips ('S') can only have hard clips ('H') between them and the end of the CIGAR string."
+                            .to_owned(),
+                        });
+                    }
+                },
                 "P" => Cigar::Pad(n),
                 "=" => Cigar::Equal(n),
                 "X" => Cigar::Diff(n),

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1140,7 +1140,7 @@ impl TryFrom<&str> for CigarString {
             }
             // get the length of the operation
             let n = u32::from_str(&text[i..j]).map_err(|_| Error::BamParseCigar {
-                msg: "Unable to parse to u32".to_owned(),
+                msg: format!("Unable to parse &str '{}' to u32.", &test[i..j]).to_owned(),
             })?;
             // get the operation
             let op = &text[j..j + 1];

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1170,7 +1170,7 @@ impl TryFrom<&[u8]> for CigarString {
                 }
                 b'S' => {
                     if i == 0
-                        || j+1 == text_len
+                        || j + 1 == text_len
                         || bytes[i-1] == b'H'
                         || bytes[j+1..].iter().all(|c| c.is_ascii_digit() || *c == b'H') {
                         Cigar::SoftClip(n)

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1140,7 +1140,7 @@ impl TryFrom<&str> for CigarString {
             }
             // get the length of the operation
             let n = u32::from_str(&text[i..j]).map_err(|_| Error::BamParseCigar {
-                msg: format!("Unable to parse &str '{}' to u32.", &text[i..j]).to_owned(),
+                msg: format!("Unable to parse &str '{}' to u32.", &text[i..j]),
             })?;
             // get the operation
             let op = &text[j..j + 1];

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1142,7 +1142,6 @@ impl TryFrom<&str> for CigarString {
     /// assert_eq!(cigar, expected_cigar);
     /// ```
     fn try_from(bytes: &[u8]) -> Result<Self> {
-        let bytes = text.as_bytes();
         let mut inner = Vec::new();
         let mut i = 0;
         let text_len = text.len();

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1110,17 +1110,6 @@ impl CigarString {
 impl TryFrom<&[u8]> for CigarString {
     type Error = Error;
 
-    /// Create a CigarString from given bytes.
-    fn try_from(text: &[u8]) -> Result<Self> {
-        Self::try_from(str::from_utf8(text).map_err(|_| Error::BamParseCigar {
-            msg: "unable to parse as UTF8".to_owned(),
-        })?)
-    }
-}
-
-impl TryFrom<&[u8]> for CigarString {
-    type Error = Error;
-
     /// Create a CigarString from given &[u8].
     /// # Example
     /// ```

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1121,7 +1121,26 @@ impl TryFrom<&[u8]> for CigarString {
 impl TryFrom<&str> for CigarString {
     type Error = Error;
 
-    /// Create a CigarString from given str.
+    /// Create a CigarString from given &str.
+    /// # Example
+    /// ```
+    /// use rust_htslib::bam::record::*;
+    /// use rust_htslib::bam::record::CigarString;
+    /// use rust_htslib::bam::record::Cigar::*;
+    /// use std::convert::TryFrom;
+    ///
+    /// let cigar_str = "2H10M5X3=2H";
+    /// let cigar = CigarString::try_from("2H10M5X3=2H")
+    ///     .expect("Unable to parse cigar string.");
+    /// let expected_cigar = CigarString(vec![
+    ///     HardClip(2),
+    ///     Match(10),
+    ///     Diff(5),
+    ///     Equal(3),
+    ///     HardClip(2),
+    /// ]);
+    /// assert_eq!(cigar, expected_cigar);
+    /// ```
     fn try_from(text: &str) -> Result<Self> {
         let bytes = text.as_bytes();
         let mut inner = Vec::new();

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1230,7 +1230,7 @@ impl TryFrom<&str> for CigarString {
     /// ```
     fn try_from(text: &str) -> Result<Self> {
         let bytes = text.as_bytes();
-        if ( text.chars().count() == bytes.len() ) {
+        if text.chars().count() != bytes.len() {
             return Err(Error::BamParseCigar {
                 msg: "CIGAR string contained non-ASCII characters, which are not valid. Valid are [0-9MIDNSHP=X].".to_owned(),
             });

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1118,7 +1118,7 @@ impl TryFrom<&[u8]> for CigarString {
     }
 }
 
-impl TryFrom<&str> for CigarString {
+impl TryFrom<&[u8]> for CigarString {
     type Error = Error;
 
     /// Create a CigarString from given &[u8].
@@ -1144,7 +1144,7 @@ impl TryFrom<&str> for CigarString {
     fn try_from(bytes: &[u8]) -> Result<Self> {
         let mut inner = Vec::new();
         let mut i = 0;
-        let text_len = text.len();
+        let text_len = bytes.len();
         while i < text_len {
             let mut j = i;
             while j < text_len && bytes[j].is_ascii_digit() {
@@ -1157,11 +1157,11 @@ impl TryFrom<&str> for CigarString {
                 });
             }
             // get the length of the operation
-            let n = u32::from_str(&text[i..j]).map_err(|_| Error::BamParseCigar {
-                msg: format!("Unable to parse &str '{}' to u32.", &text[i..j]),
+            let n = u32::from_str(&bytes[i..j]).map_err(|_| Error::BamParseCigar {
+                msg: format!("Unable to parse &str '{}' to u32.", &bytes[i..j]),
             })?;
             // get the operation
-            let op = &text[j..j + 1];
+            let op = &bytes[j..j + 1];
             inner.push(match op {
                 "M" => Cigar::Match(n),
                 "I" => Cigar::Ins(n),
@@ -1180,8 +1180,8 @@ impl TryFrom<&str> for CigarString {
                 "S" => {
                     if i == 0
                         || j+1 == text_len
-                        || &text[i-1..i] == "H"
-                        || text[j+1..].chars().all(|c| c.is_ascii_digit() || c == 'H') {
+                        || &bytes[i-1..i] == "H"
+                        || bytes[j+1..].chars().all(|c| c.is_ascii_digit() || c == 'H') {
                         Cigar::SoftClip(n)
                     } else {
                         return Err(Error::BamParseCigar {

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1859,7 +1859,8 @@ mod alignment_cigar_tests {
                 msg: "CIGAR string contained non-ASCII characters, which are not valid. Valid are [0-9MIDNSHP=X].".to_owned(),
             });
 
-        result = CigarString::try_from(cigar_str).expect_err("This should return a BamParseCigar error, but somehow didn't.");
+        result = CigarString::try_from(cigar_str)
+            .expect_err("This should return a BamParseCigar error, but somehow didn't.");
         assert_eq!(expected_error, result);
     }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1859,7 +1859,7 @@ mod alignment_cigar_tests {
                 msg: "CIGAR string contained non-ASCII characters, which are not valid. Valid are [0-9MIDNSHP=X].".to_owned(),
             });
 
-        result = CigarString::try_from(cigar_str).expect_err("This should return a BamParseCigar error, but somehow didn't.";
+        result = CigarString::try_from(cigar_str).expect_err("This should return a BamParseCigar error, but somehow didn't.");
         assert_eq!(expected_error, result);
     }
 


### PR DESCRIPTION
This is a pull request based on: https://github.com/rust-bio/rust-htslib/issues/299#issuecomment-827160458

I needed a function to turn a string slice into a cigar string from a PAF file for a whole genome alignment and I used `CigarString::try_from(&str)` to do it, but I found that it took over a minute to parse a cigar string with ~200k elements which seemed slow.

I have a feeling that maybe the regex crate is slowing this down because I cannot see anything else in the function that could be slowing it down. I rewrote the function without the regex and now it is much faster < 1s. 

I moved the old function into the test module as `regex_cigar_from_str` and then wrote a new test (`test_cigar_parsing_vs_regex`) that compares the output of `regex_cigar_from_str` and the new implementation of `try_from`. 

I also added a check that requires Hard clipping only appear at the start or end of the cigar string as requested.

I ran `cargo test`, `cargo fmt`, and `cargo clippy`. `clippy` had some warnings but nothing new so I think it should be okay. But I am brand new to rust so I hope I didn't make any errors and I appreciate any comments/corrections! Thanks. 

-Mitchell 