### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -155,12 +155,12 @@ impl RecordBuffer {
     }
 
     /// Iterate over records that have been fetched with `fetch`.
-    pub fn iter<'a>(&'a self) -> vec_deque::Iter<'a, Rc<bam::Record>> {
+    pub fn iter(&self) -> vec_deque::Iter<Rc<bam::Record>> {
         self.inner.iter()
     }
 
     /// Iterate over mutable references to records that have been fetched with `fetch`.
-    pub fn iter_mut<'a>(&'a mut self) -> vec_deque::IterMut<'a, Rc<bam::Record>> {
+    pub fn iter_mut(&mut self) -> vec_deque::IterMut<Rc<bam::Record>> {
         self.inner.iter_mut()
     }
 

--- a/src/bam/index.rs
+++ b/src/bam/index.rs
@@ -15,9 +15,9 @@ use crate::utils;
 /// Index type to build.
 pub enum Type {
     /// BAI index
-    BAI,
+    Bai,
     /// CSI index, with given minimum shift
-    CSI(u32),
+    Csi(u32),
 }
 
 /// Build a BAM index.
@@ -28,8 +28,8 @@ pub fn build<P: AsRef<Path>>(
     n_threads: u32,
 ) -> Result<()> {
     let min_shift = match idx_type {
-        Type::BAI => 0,
-        Type::CSI(min_shift) => min_shift as i32,
+        Type::Bai => 0,
+        Type::Csi(min_shift) => min_shift as i32,
     };
     let idx_path_cstr;
     let idx_path_ptr = if let Some(p) = idx_path {
@@ -69,21 +69,21 @@ mod tests {
 
         // test BAI index creation with 1 thread
         let idx1 = "test/results/test1.bam.bai";
-        build(test_bam, Some(idx1), Type::BAI, 1).unwrap();
+        build(test_bam, Some(idx1), Type::Bai, 1).unwrap();
         assert!(Path::new(idx1).exists());
 
         // test BAI index creation with 2 threads
         let idx2 = "test/results/test2.bam.bai";
-        build(test_bam, Some(idx2), Type::BAI, 2).unwrap();
+        build(test_bam, Some(idx2), Type::Bai, 2).unwrap();
         assert!(Path::new(idx2).exists());
 
         // test CSI index creation with 2 threads
         let idx3 = "test/results/test3.bam.csi";
-        build(test_bam, Some(idx3), Type::CSI(2), 2).unwrap();
+        build(test_bam, Some(idx3), Type::Csi(2), 2).unwrap();
         assert!(Path::new(idx3).exists());
 
         // test CSI index creation with 2 threads and default file name
-        build(test_bam, None, Type::CSI(5), 2).unwrap();
+        build(test_bam, None, Type::Csi(5), 2).unwrap();
         assert!(Path::new("test/test_index_build.bam.csi").exists());
     }
 }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -669,7 +669,7 @@ impl IndexedReader {
         self._inner_fetch(fetch_definition.into())
     }
 
-    fn _inner_fetch<'a>(&mut self, fetch_definition: FetchDefinition<'a>) -> Result<()> {
+    fn _inner_fetch(&mut self, fetch_definition: FetchDefinition) -> Result<()> {
         match fetch_definition {
             FetchDefinition::Region(tid, start, stop) => {
                 self._fetch_by_coord_tuple(tid, start, stop)
@@ -847,17 +847,17 @@ impl Drop for IndexedReader {
 
 #[derive(Debug, Clone, Copy)]
 pub enum Format {
-    SAM,
-    BAM,
-    CRAM,
+    Sam,
+    Bam,
+    Cram,
 }
 
 impl Format {
     fn write_mode(self) -> &'static [u8] {
         match self {
-            Format::SAM => b"w",
-            Format::BAM => b"wb",
-            Format::CRAM => b"wc",
+            Format::Sam => b"w",
+            Format::Bam => b"wb",
+            Format::Cram => b"wc",
         }
     }
 }
@@ -1778,7 +1778,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-                Format::BAM,
+                Format::Bam,
             )
             .expect("Error opening file.");
 
@@ -1830,7 +1830,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                         .push_tag(b"SN", &"chr1")
                         .push_tag(b"LN", &15072423),
                 ),
-                Format::BAM,
+                Format::Bam,
             )
             .expect("Error opening file.");
             bam.set_threads(4).unwrap();
@@ -1888,7 +1888,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                             .push_tag(b"SN", &"chr1")
                             .push_tag(b"LN", &15072423),
                     ),
-                    Format::BAM,
+                    Format::Bam,
                 )
                 .expect("Error opening file.");
 
@@ -1899,7 +1899,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                             .push_tag(b"SN", &"chr1")
                             .push_tag(b"LN", &15072423),
                     ),
-                    Format::BAM,
+                    Format::Bam,
                 )
                 .expect("Error opening file.");
 
@@ -1963,7 +1963,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             let mut bam = Writer::from_path(
                 &bampath,
                 &Header::from_template(&input_bam.header()),
-                Format::BAM,
+                Format::Bam,
             )
             .expect("Error opening file.");
 
@@ -2133,7 +2133,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     .push_tag(b"UR", &"test/test_cram.fa"),
             );
 
-            let mut cram_writer = Writer::from_path(&cram_path, &header, Format::CRAM)
+            let mut cram_writer = Writer::from_path(&cram_path, &header, Format::Cram)
                 .expect("Error opening CRAM file.");
             cram_writer.set_reference(ref_path).unwrap();
 
@@ -2197,7 +2197,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     let mut reader = Reader::from_path(&input_bam_path).unwrap();
                     let header = Header::from_template(reader.header());
                     let mut writer =
-                        Writer::from_path(&output_bam_path, &header, Format::BAM).unwrap();
+                        Writer::from_path(&output_bam_path, &header, Format::Bam).unwrap();
                     writer.set_compression_level(*level).unwrap();
                     for record in reader.records() {
                         let r = record.unwrap();
@@ -2252,7 +2252,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         {
             let mut bam_reader = Reader::from_path(bamfile).unwrap(); // internal functions, just unwarp
             let header = header::Header::from_template(bam_reader.header());
-            let mut sam_writer = Writer::from_path(samfile, &header, Format::SAM).unwrap();
+            let mut sam_writer = Writer::from_path(samfile, &header, Format::Sam).unwrap();
             for record in bam_reader.records() {
                 if record.is_err() {
                     return false;

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -15,8 +15,6 @@ use std::str;
 use std::u32;
 
 use byteorder::{LittleEndian, ReadBytesExt};
-use lazy_static::lazy_static;
-use regex::Regex;
 
 use crate::bam::Error;
 use crate::bam::HeaderView;

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -322,7 +322,7 @@ impl HeaderView {
     /// let mut header = Header::new();
     /// let contig_field = br#"##contig=<ID=foo,length=10>"#;
     /// header.push_record(contig_field);
-    /// let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// let header_view = vcf.header();
     /// let rid = header_view.name2rid(b"foo").unwrap();
     /// assert_eq!(rid, 0);

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -76,7 +76,7 @@
 //! header.push_sample("test_sample".as_bytes());
 //!
 //! // Write uncompressed VCF to stdout with above header and get an empty record
-//! let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+//! let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
 //! let mut record = vcf.empty_record();
 //!
 //! // Set chrom and pos to 1 and 7, respectively - note the 0-based positions
@@ -628,8 +628,8 @@ pub mod synced {
 
 #[derive(Clone, Copy, Debug)]
 pub enum Format {
-    VCF,
-    BCF,
+    Vcf,
+    Bcf,
 }
 
 /// A VCF/BCF writer.
@@ -694,10 +694,10 @@ impl Writer {
 
     fn new(path: &[u8], header: &Header, uncompressed: bool, format: Format) -> Result<Self> {
         let mode: &[u8] = match (uncompressed, format) {
-            (true, Format::VCF) => b"w",
-            (false, Format::VCF) => b"wz",
-            (true, Format::BCF) => b"wbu",
-            (false, Format::BCF) => b"wb",
+            (true, Format::Vcf) => b"w",
+            (false, Format::Vcf) => b"wz",
+            (true, Format::Bcf) => b"wbu",
+            (false, Format::Bcf) => b"wb",
         };
 
         let htsfile = bcf_open(path, mode)?;
@@ -913,7 +913,7 @@ mod tests {
         let header = Header::from_template_subset(&bcf.header, &[b"NA12878.subsample-0.25-0"])
             .expect("Error subsetting samples.");
         let mut writer =
-            Writer::from_path(&bcfpath, &header, false, Format::BCF).expect("Error opening file.");
+            Writer::from_path(&bcfpath, &header, false, Format::Bcf).expect("Error opening file.");
         writer.set_threads(2).unwrap();
     }
 
@@ -941,7 +941,7 @@ mod tests {
         {
             let header = Header::from_template_subset(&bcf.header, &[b"NA12878.subsample-0.25-0"])
                 .expect("Error subsetting samples.");
-            let mut writer = Writer::from_path(&bcfpath, &header, false, Format::BCF)
+            let mut writer = Writer::from_path(&bcfpath, &header, false, Format::Bcf)
                 .expect("Error opening file.");
             for rec in bcf.records() {
                 let mut record = rec.expect("Error reading record.");
@@ -1227,7 +1227,7 @@ mod tests {
                 &out_path,
                 &Header::from_template(&vcf.header()),
                 true,
-                Format::VCF,
+                Format::Vcf,
             )
             .expect("Error opening file.");
             let header = writer.header().clone();
@@ -1313,7 +1313,7 @@ mod tests {
             .remove_structured(b"Foo2")
             .remove_generic(b"Bar2");
         {
-            let mut _writer = Writer::from_path(&vcfpath, &header, true, Format::VCF)
+            let mut _writer = Writer::from_path(&vcfpath, &header, true, Format::Vcf)
                 .expect("Error opening output file.");
             // Note that we don't need to write anything, we are just looking at the header.
         }

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -140,7 +140,7 @@ impl<'a, T: 'a + fmt::Debug + fmt::Display, B: Borrow<Buffer> + 'a> fmt::Display
 /// header.push_sample("sample".as_bytes());
 ///
 /// // Write uncompressed VCF to stdout with above header and get an empty record
-/// let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+/// let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
 /// let mut record = vcf.empty_record();
 /// ```
 #[derive(Debug)]
@@ -230,7 +230,7 @@ impl Record {
     /// # let header_contig_line = r#"##contig=<ID=1,length=10>"#;
     /// # header.push_record(header_contig_line.as_bytes());
     /// # header.push_sample("test_sample".as_bytes());
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// let rid = record.header().name2rid(b"1").ok();
     /// record.set_rid(rid);
@@ -264,7 +264,7 @@ impl Record {
     /// # let tmp = NamedTempFile::new().unwrap();
     /// # let path = tmp.path();
     /// # let header = Header::new();
-    /// # let vcf = Writer::from_path(path, &header, true, Format::VCF).unwrap();
+    /// # let vcf = Writer::from_path(path, &header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// let alleles: &[&[u8]] = &[b"AGG", b"TG"];
     /// record.set_alleles(alleles).expect("Failed to set alleles");
@@ -425,7 +425,7 @@ impl Record {
     /// # header.push_sample("sample".as_bytes());
     /// #
     /// # // Write uncompressed VCF to stdout with above header and get an empty record
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// assert_eq!(record.allele_count(), 0);
     ///
@@ -521,7 +521,7 @@ impl Record {
     /// # let header_gt_line = r#"##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">"#;
     /// # header.push_record(header_gt_line.as_bytes());
     /// # header.push_sample("test_sample".as_bytes());
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// let alleles = &[GenotypeAllele::Unphased(1), GenotypeAllele::Unphased(1)];
     /// record.push_genotypes(alleles);
@@ -614,7 +614,7 @@ impl Record {
     /// # let header_af_line = r#"##FORMAT=<ID=AF,Number=1,Type=Float,Description="Frequency">"#;
     /// # header.push_record(header_af_line.as_bytes());
     /// # header.push_sample("test_sample".as_bytes());
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// record.push_format_float(b"AF", &[0.5]);
     /// assert_eq!(0.5, record.format(b"AF").float().unwrap()[0][0]);
@@ -848,7 +848,7 @@ impl Record {
     /// # header.push_sample("sample".as_bytes());
     /// #
     /// # // Write uncompressed VCF to stdout with above header and get an empty record
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// # assert_eq!(record.rlen(), 0);
     /// let alleles: &[&[u8]] = &[b"AGG", b"TG"];
@@ -871,7 +871,7 @@ impl Record {
     /// # header.push_sample("sample".as_bytes());
     /// #
     /// # // Write uncompressed VCF to stdout with above header and get an empty record
-    /// # let mut vcf = Writer::from_stdout(&header, true, Format::VCF).unwrap();
+    /// # let mut vcf = Writer::from_stdout(&header, true, Format::Vcf).unwrap();
     /// # let mut record = vcf.empty_record();
     /// let alleles: &[&[u8]] = &[b"AGG", b"TG"];
     /// record.set_alleles(alleles).expect("Failed to set alleles");
@@ -1334,7 +1334,7 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let path = tmp.path();
         let header = Header::new();
-        let vcf = Writer::from_path(path, &header, true, Format::VCF).unwrap();
+        let vcf = Writer::from_path(path, &header, true, Format::Vcf).unwrap();
         let mut record = vcf.empty_record();
         assert_eq!(record.rlen(), 0);
         let alleles: &[&[u8]] = &[b"AGG", b"TG"];
@@ -1347,7 +1347,7 @@ mod tests {
         let tmp = NamedTempFile::new().unwrap();
         let path = tmp.path();
         let header = Header::new();
-        let vcf = Writer::from_path(path, &header, true, Format::VCF).unwrap();
+        let vcf = Writer::from_path(path, &header, true, Format::Vcf).unwrap();
         let mut record = vcf.empty_record();
         let alleles: &[&[u8]] = &[b"AGG", b"TG"];
         record.set_alleles(alleles).expect("Failed to set alleles");
@@ -1362,7 +1362,7 @@ mod tests {
         let path = tmp.path();
         let mut header = Header::new();
         header.push_sample("sample".as_bytes());
-        let vcf = Writer::from_path(path, &header, true, Format::VCF).unwrap();
+        let vcf = Writer::from_path(path, &header, true, Format::Vcf).unwrap();
         let mut record = vcf.empty_record();
         let alleles: &[&[u8]] = &[b"AGG", b"TG"];
         record.set_alleles(alleles).expect("Failed to set alleles");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! let mut bam = bam::Reader::from_path(&"test/test.bam").unwrap();
 //! let header = bam::Header::from_template(bam.header());
-//! let mut out = bam::Writer::from_path(&"test/out.bam", &header, bam::Format::BAM).unwrap();
+//! let mut out = bam::Writer::from_path(&"test/out.bam", &header, bam::Format::Bam).unwrap();
 //!
 //! // copy reverse reads to new BAM file
 //! for r in bam.records() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,9 @@ pub fn copy_memory(src: &[u8], dst: &mut [u8]) {
     let len_src = src.len();
     assert!(
         dst.len() >= len_src,
-        "dst len {} < src len {}", dst.len(), src.len()
+        "dst len {} < src len {}",
+        dst.len(),
+        src.len()
     );
     // `dst` is unaliasable, so we know statically it doesn't overlap
     // with `src`.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,7 +19,7 @@ pub fn copy_memory(src: &[u8], dst: &mut [u8]) {
     let len_src = src.len();
     assert!(
         dst.len() >= len_src,
-        format!("dst len {} < src len {}", dst.len(), src.len())
+        "dst len {} < src len {}", dst.len(), src.len()
     );
     // `dst` is unaliasable, so we know statically it doesn't overlap
     // with `src`.


### PR DESCRIPTION
Just a quick PR that removes some unused imports and fixes `#[warn(non_fmt_panic)]` similar to https://github.com/rust-bio/rust-bio/pull/430. Also included some clippy lints while i was at it.