### PR TITLE
Make bcf::IndexedReader::fetch functionality inline with htslib regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - `bcf::Record` methods `end`, `clear`, and `rlen` (@mbhall88)
 
+### Changes
+- `bcf::IndexReader::fetch` parameter `end` is now an `Option<u64>`. This is inline with
+  htslib regions, which do not require an end position (@mbhall88)
+
 [Unreleased]: https://github.com/rust-bio/rust-htslib/compare/v0.36.0...HEAD
 
 ## [0.36.0] - 2020-11-23


### PR DESCRIPTION
Currently, an end position is required when fetching. This PR changes the fetch method so that `end` is now an `Option<u64>` and setting it to `None` will fetch from `start` until the last record of the contig.

I've also added 
- Some clarifying docs about the fact that the start and end positions are both 0-based inclusive
- More test cases for fetch (including to test the changes)
- Doc example of how to use `bcf::Record::format`