### PR TITLE
chore: Exclude test files from crate package.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 repository = "https://github.com/rust-bio/rust-htslib.git"
 documentation = "https://docs.rs/rust-htslib"
 edition = "2018"
+include = ["src/**/*", "LICENSE.md", "README.md", "CHANGELOG.md"]
 
 [workspace]
 members = ["hts-sys"]

--- a/hts-sys/Cargo.toml
+++ b/hts-sys/Cargo.toml
@@ -20,7 +20,7 @@ tag-message = "Version {{version}} of Rust-HTSlib."
 libz-sys = { version = "1.1.0", default-features = false, features = ["zlib-ng", "static"] }
 bzip2-sys = { version = "0.1.8", optional = true }
 lzma-sys = { version = "0.1.16", optional = true, features = ["static"] }
-curl-sys = { version = "0.4.44+curl-7.77.1", optional = true, features = ["static-curl", "static-ssl", "protocol-ftp"] }
+curl-sys = { version = "0.4.44", optional = true, features = ["static-curl", "static-ssl", "protocol-ftp"] }
 libdeflate-sys = { version = "0.5.0", optional = true }
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]

--- a/hts-sys/build.rs
+++ b/hts-sys/build.rs
@@ -154,14 +154,12 @@ fn main() {
             if target_os == "macos" {
                 // Use builtin MacOS CommonCrypto HMAC
                 config_lines.push("#define HAVE_COMMONCRYPTO 1");
+            } else if let Ok(inc) = env::var("DEP_OPENSSL_INCLUDE").map(PathBuf::from) {
+                // Must use hmac from libcrypto in openssl
+                cfg.include(inc);
+                config_lines.push("#define HAVE_HMAC 1");
             } else {
-                if let Ok(inc) = env::var("DEP_OPENSSL_INCLUDE").map(PathBuf::from) {
-                    // Must use hmac from libcrypto in openssl
-                    cfg.include(inc);
-                    config_lines.push("#define HAVE_HMAC 1");
-                } else {
-                    panic!("No OpenSSL dependency -- need OpenSSL includes");
-                }
+                panic!("No OpenSSL dependency -- need OpenSSL includes");
             }
         }
     }

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -713,7 +713,7 @@ impl IndexedReader {
                             .unwrap();
                         self._fetch_by_coord_tuple(tid as i32, 0, len)
                     }
-                    None => self._fetch_by_str(&s),
+                    None => self._fetch_by_str(s),
                 }
             }
             FetchDefinition::All => self._fetch_by_str(b"."),

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -53,7 +53,7 @@ impl<'de> Deserialize<'de> for Record {
             Mpos,
             Isize,
             Data,
-        };
+        }
 
         impl<'de> Deserialize<'de> for Field {
             fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -298,7 +298,7 @@ impl<'de> Deserialize<'de> for Record {
             }
         }
 
-        const FIELDS: &'static [&'static str] = &[
+        const FIELDS: &[&str] = &[
             "tid", "pos", "bin", "qual", "l_qname", "flag", "n_cigar", "seq_len", "mtid", "mpos",
             "isize", "data",
         ];

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -385,7 +385,7 @@ impl Record {
         if flt_id.is_pass() && self.inner().d.n_flt == 0 {
             return true;
         }
-        let id = match flt_id.id_from_header(&self.header()) {
+        let id = match flt_id.id_from_header(self.header()) {
             Ok(i) => *i,
             Err(_) => return false,
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,17 +110,12 @@
 
 #[macro_use]
 extern crate custom_derive;
-extern crate libc;
+
 #[macro_use]
 extern crate newtype_derive;
 
 #[cfg(feature = "serde_feature")]
 extern crate serde;
-#[cfg(feature = "serde_feature")]
-extern crate serde_bytes;
-
-#[cfg(all(test, feature = "serde_feature"))]
-extern crate bincode;
 
 #[cfg(test)] // <-- not needed in examples + integration tests
 #[macro_use]


### PR DESCRIPTION
Exclude `test`, `docker`, `.github` files from packaged crate.

Also, fix two warnings which come up in nightly rust:
```
warning: hts-sys/Cargo.toml: version requirement `0.4.44+curl-7.77.1` for dependency `curl-sys` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion

warning: unnecessary trailing semicolon
  --> src/bam/record_serde.rs:56:10
   |
56 |         };
   |          ^ help: remove this semicolon
   |
   = note: `#[warn(redundant_semicolons)]` on by default
```

Remove unnecessary extern crate directives, which are no longer required with the 2018 edition.

Fix a couple of trivial clippy warnings.