### PR TITLE
Workaround Non-Threadsafe Use of `Rc` in `bam::record::Record`

### DIFF
--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -223,7 +223,7 @@ pub trait Read: Sized {
 #[derive(Debug)]
 pub struct Reader {
     htsfile: *mut htslib::htsFile,
-    header: Rc<HeaderView>,
+    header: HeaderView,
     tpool: Option<ThreadPool>,
 }
 
@@ -271,7 +271,7 @@ impl Reader {
 
         Ok(Reader {
             htsfile,
-            header: Rc::new(HeaderView::new(header)),
+            header: HeaderView::new(header),
             tpool: None,
         })
     }
@@ -355,11 +355,7 @@ impl Read for Reader {
             -1 => None,
             -2 => Some(Err(Error::BamTruncatedRecord)),
             -4 => Some(Err(Error::BamInvalidRecord)),
-            _ => {
-                record.set_header(Rc::clone(&self.header));
-
-                Some(Ok(()))
-            }
+            _ => Some(Ok(())),
         }
     }
 
@@ -793,11 +789,7 @@ impl Read for IndexedReader {
                     -1 => None,
                     -2 => Some(Err(Error::BamTruncatedRecord)),
                     -4 => Some(Err(Error::BamInvalidRecord)),
-                    _ => {
-                        record.set_header(Rc::clone(&self.header));
-
-                        Some(Ok(()))
-                    }
+                    _ => Some(Ok(())),
                 }
             }
             None => None,
@@ -1321,6 +1313,7 @@ mod tests {
     use super::header::HeaderRecord;
     use super::record::{Aux, Cigar, CigarString};
     use super::*;
+    use bio_types::genome::AbstractInterval;
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;


### PR DESCRIPTION
Hey all, this is an attempt to work around #293 (for context please see the discussion there).

I simply removed the reference counted reference to `HeaderView` from BAM `Record`s and impl'ed `genome::AbstractInterval` on a wrapper type around `&Record` and `&HeaderView`. This wrapper type can be constructed like this:
```Rust
let header = bam_reader.header().clone();
for record in bam_reader.records() {
    let mut rec = record.unwrap();
    // `.contig()` is a member of the `genome::AbstractInterval` trait
    let contig = rec.supply_header(&header).contig();
}
```
This is not exactly elegant and I don't know the use cases that made references to headers necessary in the first place, so please let me know if this workaround is viable at all. 

We should definitely try and remove other unsound `unsafe` impls of `Send` and `Sync` for structs containing `Rc` as well.