### PR TITLE
fix: fixed fn to_hashmap so it can avoid an error when @CO tag appeared

### DIFF
--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -7,8 +7,8 @@ use crate::bam::HeaderView;
 use lazy_static::lazy_static;
 use linear_map::LinearMap;
 use regex::Regex;
-use std::collections::HashMap;
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 /// A BAM header.
 #[derive(Debug, Clone)]
@@ -104,25 +104,24 @@ impl Header {
         }
         header_map
     }
-    
+
     /// Returns an iterator of comment lines.
     /// # Example
     /// ```
     /// # We can reproduce comment lines as below
-    /// 
+    ///
     /// let bam = bam::Reader::from_path(&"test.bam").unwrap();
     /// let header = bam::Header::from_template(bam.header());
     /// for comment in header.comments() {
     ///     println!("@CO\t{}", comment);
     /// }
     /// ```
-    pub fn comments(&self) -> impl Iterator<Item=Cow<str>> {
-        self.records.iter()
-            .flat_map(|r| r
-                .split(|x| x == &b'\n')
+    pub fn comments(&self) -> impl Iterator<Item = Cow<str>> {
+        self.records.iter().flat_map(|r| {
+            r.split(|x| x == &b'\n')
                 .filter(|x| x.starts_with(b"@CO\t"))
                 .map(|x| String::from_utf8_lossy(&x[4..]))
-            )
+        })
     }
 }
 

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -107,9 +107,8 @@ impl Header {
 
     /// Returns an iterator of comment lines.
     /// # Example
+    /// We can reproduce comment lines as below.
     /// ```
-    /// # We can reproduce comment lines as below
-    ///
     /// let bam = bam::Reader::from_path(&"test.bam").unwrap();
     /// let header = bam::Header::from_template(bam.header());
     /// for comment in header.comments() {

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -63,6 +63,9 @@ impl Header {
         self.records.join(&b'\n')
     }
 
+    /// This returns a header as a HashMap.
+    /// Comment lines starting with "@CO" will NOT be included in the HashMap.
+    /// Comment lines can be obtained by the `get_comments` function.
     pub fn to_hashmap(&self) -> HashMap<String, Vec<LinearMap<String, String>>> {
         let mut header_map = HashMap::default();
 
@@ -99,6 +102,26 @@ impl Header {
                 .push(field);
         }
         header_map
+    }
+    
+    /// This returns comments in a header as a vector.
+    /// If a header does not have any comment line, this returns `None`.
+    pub fn get_comments(&self) -> Option<Vec<String>> {
+        let mut vec: Vec<String> = Vec::new();
+        let header_string = String::from_utf8(self.to_bytes()).unwrap();
+        for line in header_string.split('\n').filter(|x| !x.is_empty()) {
+            if line.starts_with("@CO\t") {
+                match line.split_once("\t") {
+                    Some((tag, value)) => vec.push(value.to_string()),
+                    None => (),  // This should never happen.
+                }
+            }
+        }
+        if vec.len() >= 1 {
+            Some(vec)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -83,6 +83,9 @@ impl Header {
                 .unwrap()
                 .as_str()
                 .to_owned();
+            if record_type.eq("CO") {
+                continue;
+            }
             let mut field = LinearMap::default();
             for part in parts.iter().skip(1) {
                 let cap = TAG_RE.captures(part).unwrap();

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -106,15 +106,6 @@ impl Header {
     }
 
     /// Returns an iterator of comment lines.
-    /// # Example
-    /// We can reproduce comment lines as below.
-    /// ```no_run
-    /// let bam = bam::Reader::from_path(&"test.bam").unwrap();
-    /// let header = bam::Header::from_template(bam.header());
-    /// for comment in header.comments() {
-    ///     println!("@CO\t{}", comment);
-    /// }
-    /// ```
     pub fn comments(&self) -> impl Iterator<Item = Cow<str>> {
         self.records.iter().flat_map(|r| {
             r.split(|x| x == &b'\n')

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -108,7 +108,7 @@ impl Header {
     /// Returns an iterator of comment lines.
     /// # Example
     /// We can reproduce comment lines as below.
-    /// ```
+    /// ```no_run
     /// let bam = bam::Reader::from_path(&"test.bam").unwrap();
     /// let header = bam::Header::from_template(bam.header());
     /// for comment in header.comments() {

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -330,6 +330,7 @@ pub struct Records<'a, R: Read> {
 impl<'a, R: Read> Iterator for Records<'a, R> {
     type Item = Result<Vec<u8>>;
 
+    #[allow(clippy::read_zero_byte_vec)]
     fn next(&mut self) -> Option<Result<Vec<u8>>> {
         let mut record = Vec::new();
         match self.reader.read(&mut record) {


### PR DESCRIPTION
When a header contains `@CO` line(s), it may issue an error at the line 88 of [4d99455](https://github.com/rust-bio/rust-htslib/commit/4d9945578285b5abcbf741eae484fee14b2a596e) (`let cap = TAG_RE.captures(part).unwrap();`) because `@CO` line may not have values of "([A-Za-z][A-Za-z0-9]):([ -~]+)".

E.g.
ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/illumina_platinum_pedigree/data/CEU/NA12878/alignment/NA12878.alt_bwamem_GRCh38DH.20150706.CEU.illumina_platinum_ped.cram

Header lines:

```
samtools view -H NA12878.alt_bwamem_GRCh38DH.20150706.CEU.illumina_platinum_ped.cram | tail -n 5

@CO     $known_indels_file(s) = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/other_mapping_resources/Mills_and_1000G_gold_standard.indels.b38.primary_assembly.vcf.gz
@CO     $known_indels_file(s) = ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/other_mapping_resources/ALL.wgs.1000G_phase3.GRCh38.ncbi_remapper.20150424.shapeit2_indels.vcf.gz
@CO     FASTQ=ERR194147_1.fastq.gz
@CO     FASTQ=ERR194147_2.fastq.gz
@CO     FASTQ=ERR194147.fastq.gz
```

Error:

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /home/kooojiii/.cargo/registry/src/github.com-1ecc6299db9ec823/rust-htslib-0.39.5/src/bam/header.rs:88:49
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panicking.rs:143:14
   2: core::panicking::panic
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panicking.rs:48:5
   3: rust_htslib::bam::header::Header::to_hashmap
```
