### PR TITLE
feat: Revised calculation of leading- and trailing-softclips

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: 0.25.0
           args: '--all-features --out Lcov --exclude-files hts-sys/*_prebuilt_bindings.rs -- --test-threads 1'
 
       - name: Upload coverage

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,7 +67,6 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: 0.22.0
           args: '--all-features --out Lcov --exclude-files hts-sys/*_prebuilt_bindings.rs -- --test-threads 1'
 
       - name: Upload coverage

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1912,7 +1912,7 @@ impl<'a> IntoIterator for &'a CigarString {
     type IntoIter = ::std::slice::Iter<'a, Cigar>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&(self.0)).iter()
+        self.0.iter()
     }
 }
 
@@ -1927,13 +1927,12 @@ impl fmt::Display for CigarString {
 
 // Get number of leading/trailing softclips if a CigarString taking hardclips into account
 fn calc_softclips<'a>(mut cigar: impl DoubleEndedIterator<Item = &'a Cigar>) -> i64 {
-    let softclips = match (cigar.next(), cigar.next()) {
+    match (cigar.next(), cigar.next()) {
         (Some(Cigar::HardClip(_)), Some(Cigar::SoftClip(s))) | (Some(Cigar::SoftClip(s)), _) => {
             *s as i64
         }
         _ => 0,
-    };
-    softclips
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug)]

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1960,24 +1960,26 @@ impl CigarStringView {
 
     /// Get number of bases softclipped at the beginning of the alignment.
     pub fn leading_softclips(&self) -> i64 {
-        self.first().map_or(0, |cigar| {
-            if let Cigar::SoftClip(s) = cigar {
-                *s as i64
-            } else {
-                0
-            }
-        })
+        self.split_first()
+            .map_or(0, |(leading_cigar, trailing_cigars)| match leading_cigar {
+                Cigar::SoftClip(s) => *s as i64,
+                Cigar::HardClip(_) => CigarString(trailing_cigars.to_vec())
+                    .into_view(0)
+                    .leading_softclips(),
+                _ => 0,
+            })
     }
 
     /// Get number of bases softclipped at the end of the alignment.
     pub fn trailing_softclips(&self) -> i64 {
-        self.last().map_or(0, |cigar| {
-            if let Cigar::SoftClip(s) = cigar {
-                *s as i64
-            } else {
-                0
-            }
-        })
+        self.split_last()
+            .map_or(0, |(trailing_cigar, leading_cigars)| match trailing_cigar {
+                Cigar::SoftClip(s) => *s as i64,
+                Cigar::HardClip(_) => CigarString(leading_cigars.to_vec())
+                    .into_view(0)
+                    .trailing_softclips(),
+                _ => 0,
+            })
     }
 
     /// Get number of bases hardclipped at the beginning of the alignment.

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -2195,17 +2195,27 @@ mod tests {
 
     #[test]
     fn test_cigar_string_leading_softclips() {
-        let cigar = CigarString(vec![Cigar::SoftClip(10), Cigar::Match(100)]);
+        let cigar = CigarString(vec![Cigar::SoftClip(10), Cigar::Match(100)]).into_view(0);
         assert_eq!(cigar.leading_softclips(), 10);
-        let cigar2 = CigarString(vec![Cigar::HardClip(5), Cigar::SoftClip(10), Cigar::Match(100)]);
+        let cigar2 = CigarString(vec![
+            Cigar::HardClip(5),
+            Cigar::SoftClip(10),
+            Cigar::Match(100),
+        ])
+        .into_view(0);
         assert_eq!(cigar2.leading_softclips(), 10);
     }
 
     #[test]
     fn test_cigar_string_trailing_softclips() {
-        let cigar = CigarString(vec![Cigar::Match(100), Cigar::SoftClip(10)]);
+        let cigar = CigarString(vec![Cigar::Match(100), Cigar::SoftClip(10)]).into_view(0);
         assert_eq!(cigar.trailing_softclips(), 10);
-        let cigar2 = CigarString(vec![Cigar::Match(100), Cigar::SoftClip(10), Cigar::HardClip(5)]);
+        let cigar2 = CigarString(vec![
+            Cigar::Match(100),
+            Cigar::SoftClip(10),
+            Cigar::HardClip(5),
+        ])
+        .into_view(0);
         assert_eq!(cigar2.trailing_softclips(), 10);
     }
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -2194,6 +2194,22 @@ mod tests {
     }
 
     #[test]
+    fn test_cigar_string_leading_softclips() {
+        let cigar = CigarString(vec![Cigar::SoftClip(10), Cigar::Match(100)]);
+        assert_eq!(cigar.leading_softclips(), 10);
+        let cigar2 = CigarString(vec![Cigar::HardClip(5), Cigar::SoftClip(10), Cigar::Match(100)]);
+        assert_eq!(cigar2.leading_softclips(), 10);
+    }
+
+    #[test]
+    fn test_cigar_string_trailing_softclips() {
+        let cigar = CigarString(vec![Cigar::Match(100), Cigar::SoftClip(10)]);
+        assert_eq!(cigar.trailing_softclips(), 10);
+        let cigar2 = CigarString(vec![Cigar::Match(100), Cigar::SoftClip(10), Cigar::HardClip(5)]);
+        assert_eq!(cigar2.trailing_softclips(), 10);
+    }
+
+    #[test]
     fn test_cigar_read_pos() {
         let vpos = 5; // variant position
 

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1777,7 +1777,7 @@ impl CigarString {
     }
 
     // Get number of leading/trailing softclips taking hardclips into account
-    fn get_softclips(self) -> i64 {
+    fn calc_leading_softclips(&self) -> i64 {
         match (self.get(0), self.get(1)) {
             (Some(Cigar::HardClip(_)), Some(Cigar::SoftClip(s))) => *s as i64,
             (Some(Cigar::SoftClip(s)), _) => *s as i64,
@@ -1970,14 +1970,14 @@ impl CigarStringView {
 
     /// Get number of bases softclipped at the beginning of the alignment.
     pub fn leading_softclips(&self) -> i64 {
-        self.to_owned().take().get_softclips()
+        self.to_owned().take().calc_leading_softclips()
     }
 
     /// Get number of bases softclipped at the end of the alignment.
     pub fn trailing_softclips(&self) -> i64 {
         let mut cigar = self.to_owned().take();
         cigar.reverse();
-        cigar.get_softclips()
+        cigar.calc_leading_softclips()
     }
 
     /// Get number of bases hardclipped at the beginning of the alignment.

--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -1925,7 +1925,7 @@ impl fmt::Display for CigarString {
     }
 }
 
-// Get number of leaading/trailing softclips taking hardclips into account
+// Get number of leading/trailing softclips taking hardclips into account
 fn get_softclips(cigar: CigarString) -> i64 {
     match (cigar.get(0), cigar.get(1)) {
         (Some(Cigar::HardClip(_)), Some(Cigar::SoftClip(s))) => *s as i64,


### PR DESCRIPTION
The `leading_softclips` and `trailing_softclips` functions of `CigarStringView` objects return 0 softclips in case of hardclipping operations between the softclips and the end of the cigar string e.g `50M5S10H`.
While it is true that the example Cigar is not concluded by a softclip and therefore returns 0 softclips I would argue that the functions should always returns the number of softclips on the corresonding end no matter if there are hardclips or not.
As softclips are part of a records sequence they need to be taken into account when determining unaligned read positions independently of hardclips.

Note:
As I implemented a recursive call of `leading/trailing_softclip` functions I had to rebuild a new CigarStringView when I just set the position to 0. I do not see any issue with that but just want to point that out in case one comes up with a less sloppy implementation.