### PR TITLE
ci: Pin tarpaulin version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           args: '--all-features --out Lcov --exclude-files hts-sys/*_prebuilt_bindings.rs -- --test-threads 1'
+          version: 0.22.0
 
       - name: Upload coverage
         uses: coverallsapp/github-action@v1.1.1


### PR DESCRIPTION
Similar to https://github.com/koesterlab/alignoth/pull/82. See https://github.com/actions-rs/tarpaulin/issues/15 for more information. 