### PR TITLE
feat: Add ability to fetch number of sequences and I-th sequence from FAI index

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -31,6 +31,8 @@ pub enum Error {
     // Errors for faidx
     #[error("The given position is too large to be converted to i64")]
     FaidxPositionTooLarge,
+    #[error("bad conversion of sequence name")]
+    FaidxBadSeqName,
 
     // Errors for Tbx
     #[error("previous iterator generation failed")]

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -111,7 +111,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `i` - index to query
-    pub fn fetch_i_seq(&self, i: i32) -> Result<String> {
+    pub fn seq_name(&self, i: i32) -> Result<String> {
         let cname = unsafe {
             let ptr = htslib::faidx_iseq(self.inner, i);
             ffi::CStr::from_ptr(ptr)

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -101,7 +101,7 @@ impl Reader {
     }
 
     /// Fetches the number of sequences in the fai index
-    pub fn fetch_n_seqs(&self) -> u64 {
+    pub fn n_seqs(&self) -> u64 {
         let n = unsafe { htslib::faidx_nseq(self.inner) };
         n as u64
     }

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -99,6 +99,33 @@ impl Reader {
         let bytes = self.fetch_seq(name, begin, end)?;
         Ok(std::str::from_utf8(bytes).unwrap().to_owned())
     }
+
+    /// Fetches the number of sequences in the fai index
+    pub fn fetch_n_seqs(&self) -> u64 {
+        let n = unsafe { htslib::faidx_nseq(self.inner) };
+        n as u64
+    }
+
+    /// Fetches the i-th sequence name
+    ///
+    /// # Arguments
+    ///
+    /// * `i` - index to query
+    pub fn fetch_i_seq(&self, i: i32) -> Result<String> {
+        let cname = unsafe {
+            let ptr = htslib::faidx_iseq(self.inner, i);
+            ffi::CStr::from_ptr(ptr)
+        };
+
+        let out = match cname.to_str() {
+            Ok(s) => s.to_string(),
+            Err(_) => {
+                return Err(Error::FaidxBadSeqName);
+            }
+        };
+
+        Ok(out)
+    }
 }
 
 #[cfg(test)]

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -225,4 +225,17 @@ mod tests {
         let res = r.fetch_seq("chr1", position_too_large, position_too_large + 1);
         assert_eq!(res, Err(Error::FaidxPositionTooLarge));
     }
+
+    #[test]
+    fn faidx_n_seqs() {
+        let r = open_reader();
+        assert_eq!(r.n_seqs(), 3);
+    }
+
+    #[test]
+    fn faidx_seq_name() {
+        let r = open_reader();
+        let n = r.seq_name(1).unwrap();
+        assert_eq!(n, "chr2");
+    }
 }


### PR DESCRIPTION
`faidx.c` has two functions for retrieving the number of sequences in the FAI index (`faidx_nseq`) and the name of the I-th sequence (`faidx_iseq`). Previously these two functions weren't accessible through `rust-htslib`. I've added a function to access each of these into the `faidx` module.

This is my first PR for `rust-htslib`, so let me know if there are any things I can improve upon in my code!