### PR TITLE
fix: Allow empty tags in BAM header

### DIFF
--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -72,7 +72,7 @@ impl Header {
 
         lazy_static! {
             static ref REC_TYPE_RE: Regex = Regex::new(r"@([A-Z][A-Z])").unwrap();
-            static ref TAG_RE: Regex = Regex::new(r"([A-Za-z][A-Za-z0-9]):([ -~]+)").unwrap();
+            static ref TAG_RE: Regex = Regex::new(r"([A-Za-z][A-Za-z0-9]):([ -~]*)").unwrap();
         }
 
         let header_string = String::from_utf8(self.to_bytes()).unwrap();


### PR DESCRIPTION
Hello, 

I recently ran into an issue where BAM files with empty tags in their header fail with rust-htslib whereas they work fine with samtools and even with `quickcheck` within samtools. For example a barcode tag without a value (`BC:`) within `@RG` would throw an unwrap error when using `to_hashmap`. 

This just needs a one character change in the regex `+` -> `*`, so hopefully wont cause any issues or changes in compatibility. 

Thanks for considering!
Mitchell
