### PR TITLE
fix: implement Drop for faidx::Reader, destroying the fai handle

### DIFF
--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -128,6 +128,14 @@ impl Reader {
     }
 }
 
+impl Drop for Reader {
+    fn drop(&mut self) {
+        unsafe {
+            htslib::fai_destroy(self.inner);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -246,4 +246,12 @@ mod tests {
         let n = r.seq_name(1).unwrap();
         assert_eq!(n, "chr2");
     }
+
+    #[test]
+    fn open_many_readers() {
+        for _ in 0..500_000 {
+            let reader = open_reader();
+            drop(reader);
+        }
+    }
 }


### PR DESCRIPTION
It seems the faidx::Reader had no implementation for `Drop`, hence not correctly handling its inner htslib faidx handle. This *might* fix #390.

Todo:
- [x] add a testcase opening and subsequently dropping many faidx handles