### PR TITLE
fix: use correct return value in bcf_get_format and bcf_get_info_values

### DIFF
--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1027,12 +1027,7 @@ mod tests {
                 .string()
                 .expect("Error reading string.");
             assert_eq!(fs1_str_vec.len(), 2);
-            println!(
-                "{}",
-                String::from_utf8_lossy(
-                    fs1_str_vec[0]
-                )
-            );
+            println!("{}", String::from_utf8_lossy(fs1_str_vec[0]));
             assert_eq!(
                 record
                     .format(b"FS1")

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1022,13 +1022,15 @@ mod tests {
                     .expect("Missing tag")[0],
                 format!("string{}", i + 1).as_bytes()
             );
+            let fs1_str_vec = record
+                .format(b"FS1")
+                .string()
+                .expect("Error reading string.");
+            assert_eq!(fs1_str_vec.len(), 1);
             println!(
                 "{}",
                 String::from_utf8_lossy(
-                    record
-                        .format(b"FS1")
-                        .string()
-                        .expect("Error reading string.")[0]
+                    fs1_str_vec[0]
                 )
             );
             assert_eq!(

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1026,7 +1026,7 @@ mod tests {
                 .format(b"FS1")
                 .string()
                 .expect("Error reading string.");
-            assert_eq!(fs1_str_vec.len(), 1);
+            assert_eq!(fs1_str_vec.len(), 2);
             println!(
                 "{}",
                 String::from_utf8_lossy(

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -1023,7 +1023,7 @@ mod tests {
                 format!("string{}", i + 1).as_bytes()
             );
             let fs1_str_vec = record
-                .format(b"FS1")
+                .format_shared_buffer(b"FS1", &mut buffer)
                 .string()
                 .expect("Error reading string.");
             assert_eq!(fs1_str_vec.len(), 2);

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -1285,8 +1285,9 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Info<'a, B> {
     pub fn integer(mut self) -> Result<Option<BufferBacked<'b, &'b [i32], B>>> {
         self.data(htslib::BCF_HT_INT).map(|data| {
             data.map(|ret| {
-                let values =
-                    unsafe { slice::from_raw_parts(self.buffer.borrow().inner as *const i32, ret as usize) };
+                let values = unsafe {
+                    slice::from_raw_parts(self.buffer.borrow().inner as *const i32, ret as usize)
+                };
                 BufferBacked::new(&values[..ret as usize], self.buffer)
             })
         })
@@ -1303,8 +1304,9 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Info<'a, B> {
     pub fn float(mut self) -> Result<Option<BufferBacked<'b, &'b [f32], B>>> {
         self.data(htslib::BCF_HT_REAL).map(|data| {
             data.map(|ret| {
-                let values =
-                    unsafe { slice::from_raw_parts(self.buffer.borrow().inner as *const f32, ret as usize) };
+                let values = unsafe {
+                    slice::from_raw_parts(self.buffer.borrow().inner as *const f32, ret as usize)
+                };
                 BufferBacked::new(&values[..ret as usize], self.buffer)
             })
         })
@@ -1436,10 +1438,15 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Format<'a, B> {
     pub fn integer(mut self) -> Result<BufferBacked<'b, Vec<&'b [i32]>, B>> {
         self.data(htslib::BCF_HT_INT).map(|ret| {
             BufferBacked::new(
-                unsafe { slice::from_raw_parts(self.buffer.borrow_mut().inner as *const i32, ret as usize) }
-                    .chunks(self.values_per_sample())
-                    .map(|s| trim_slice(s))
-                    .collect(),
+                unsafe {
+                    slice::from_raw_parts(
+                        self.buffer.borrow_mut().inner as *const i32,
+                        ret as usize,
+                    )
+                }
+                .chunks(self.values_per_sample())
+                .map(|s| trim_slice(s))
+                .collect(),
                 self.buffer,
             )
         })
@@ -1454,10 +1461,15 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Format<'a, B> {
     pub fn float(mut self) -> Result<BufferBacked<'b, Vec<&'b [f32]>, B>> {
         self.data(htslib::BCF_HT_REAL).map(|ret| {
             BufferBacked::new(
-                unsafe { slice::from_raw_parts(self.buffer.borrow_mut().inner as *const f32, ret as usize) }
-                    .chunks(self.values_per_sample())
-                    .map(|s| trim_slice(s))
-                    .collect(),
+                unsafe {
+                    slice::from_raw_parts(
+                        self.buffer.borrow_mut().inner as *const f32,
+                        ret as usize,
+                    )
+                }
+                .chunks(self.values_per_sample())
+                .map(|s| trim_slice(s))
+                .collect(),
                 self.buffer,
             )
         })
@@ -1472,15 +1484,17 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Format<'a, B> {
     pub fn string(mut self) -> Result<BufferBacked<'b, Vec<&'b [u8]>, B>> {
         self.data(htslib::BCF_HT_STR).map(|ret| {
             BufferBacked::new(
-                unsafe { slice::from_raw_parts(self.buffer.borrow_mut().inner as *const u8, ret as usize) }
-                    .chunks(self.values_per_sample())
-                    .map(|s| {
-                        // stop at zero character
-                        s.split(|c| *c == 0u8)
-                            .next()
-                            .expect("Bug: returned string should not be empty.")
-                    })
-                    .collect(),
+                unsafe {
+                    slice::from_raw_parts(self.buffer.borrow_mut().inner as *const u8, ret as usize)
+                }
+                .chunks(self.values_per_sample())
+                .map(|s| {
+                    // stop at zero character
+                    s.split(|c| *c == 0u8)
+                        .next()
+                        .expect("Bug: returned string should not be empty.")
+                })
+                .collect(),
                 self.buffer,
             )
         })

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -1270,7 +1270,7 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Info<'a, B> {
             -1 => Err(Error::BcfUndefinedTag { tag: self.desc() }),
             -2 => Err(Error::BcfUnexpectedType { tag: self.desc() }),
             -3 => Ok(None),
-            ret => Ok(Some((n as usize, ret))),
+            ret => Ok(Some((ret as usize, ret))),
         }
     }
 
@@ -1423,7 +1423,7 @@ impl<'a, 'b, B: BorrowMut<Buffer> + Borrow<Buffer> + 'b> Format<'a, B> {
                 tag: self.desc(),
                 record: self.record.desc(),
             }),
-            ret => Ok((n as usize, ret)),
+            ret => Ok((ret as usize, ret)),
         }
     }
 


### PR DESCRIPTION
According to the [notes in htslib vcf header file](https://github.com/samtools/htslib/blob/7f69840c2fbf73dc7601c17a3ade4db676858cf4/htslib/vcf.h#L1118-L1120):

> Use the returned number of written values for accessing valid entries of dst, as ndst is only a
> watermark that can be higher than the returned value, i.e. the end of dst can contain carry-over
> values from previous calls to bcf_get_format_*() on lines with more values per sample.

I had a case that when accessing a format field of string type, even there was only one sample, I got two strings returned (albeit the second one was empty). With this change, the issue was fixed.

