### PR TITLE
ci: Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Prefix all commit messages with "deps: ", which should be
+      # accepted as a conventional commit and trigger release-please
+      prefix: "deps"


### PR DESCRIPTION
Enable [Dependabot](https://docs.github.com/en/code-security/dependabot) to open PRs to update dependencies.

Related PR in `rust-bio/rust-bio`:

- <https://github.com/rust-bio/rust-bio/pull/536>
