### PR TITLE
move empty_record to header

### DIFF
--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -237,7 +237,7 @@ impl Read for Reader {
 
     /// Return empty record.  Can be reused multiple times.
     fn empty_record(&self) -> Record {
-        Record::new(Rc::clone(&self.header))
+        self.header.empty_record()
     }
 }
 


### PR DESCRIPTION
this makes it so we don't need access to the VCF struct in order to make an empty record. since the header is always available as record.header() then we can create an empty record