### PR TITLE
fix: bump url from 2.1 to 2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ regex = "1.3"
 serde = {version = "^1", optional = true, features = ["derive"]}
 serde_bytes = {version = "0.11", optional = true}
 thiserror = {version = "^2" }
-url = "2.1"
+url = "2.5"
 
 [features]
 bindgen = ["hts-sys/bindgen"]


### PR DESCRIPTION
idna versions less than version 1.0.3 are impacted by RUSTSEC-2024-0421. Uprevving url to a version
greater than 2.5.4 will use a version of idna that is not impacted by this vulnerability.

TEST=cargo test

Fixes: #460 