### PR TITLE
ci: Small cleanup of the Github Actions in the PR workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository_owner == 'rust-bio'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -22,26 +22,22 @@ jobs:
           bump-minor-pre-major: true
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         if: ${{ steps.release_main.outputs.release_created }}
         with:
           toolchain: stable
-          override: true
 
       - name: Install system dependencies
         if: ${{ steps.release_main.outputs.release_created }}
         run: |
           sudo apt-get install --yes zlib1g-dev libbz2-dev musl musl-dev musl-tools clang libc6-dev
 
-      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: Swatinem/rust-cache@v2
         if: ${{ steps.release_main.outputs.release_created }}
 
       - name: Publish rust-htslib
         if: ${{ steps.release_main.outputs.release_created }}
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
 
       # - uses: katyo/publish-crates@v1
       #   if: ${{ steps.release_main.outputs.release_created || steps.release_sys.outputs.release_created }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,10 @@ jobs:
 
   Testing:
     needs: Formatting
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -75,6 +78,7 @@ jobs:
     needs: Formatting
     strategy:
       matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
         target:
           - no-default-features
           - all-features
@@ -82,6 +86,7 @@ jobs:
           - target: no-default-features
             args: --no-default-features
           - target: all-features
+            os: ubuntu-22.04
             args: --all-features
             toolchain_target: x86_64-unknown-linux-musl
           - target: all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,78 +8,71 @@ on:
 
 jobs:
   Formatting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: rustfmt
 
       - name: Check format
         run: cargo fmt -- --check
 
   Linting:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
           components: clippy
 
       - name: Lint with clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: RUSTFLAGS="-Dwarnings" cargo clippy --all-features --all-targets -- -Dclippy::all -Dunused_imports
 
   Testing:
     needs: Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-          override: true
 
       - name: Install system dependencies
         run: |
           sudo apt-get install --yes zlib1g-dev libbz2-dev musl musl-dev musl-tools clang libc6-dev
 
-      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: Swatinem/rust-cache@v2
 
       - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          # TODO: update to latest tarpaulin once artefact download is fixed: https://github.com/actions-rs/tarpaulin/pull/23
-          version: "0.22.0"
-          args: "--all-features --run-types Tests,Doctests --out Lcov -- --test-threads 1"
+        run: |
+          set -x
+          cargo install cargo-tarpaulin
+          cargo tarpaulin --all-features --tests --doc --out Lcov -- --test-threads 1
 
       - name: Upload coverage
-        uses: coverallsapp/github-action@v1
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./lcov.info
 
   Testing-Features:
     needs: Formatting
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -88,36 +81,35 @@ jobs:
         include:
           - target: no-default-features
             args: --no-default-features
-            use_cross: false
           - target: all-features
             args: --all-features
             toolchain_target: x86_64-unknown-linux-musl
-            use_cross: false
+          - target: all-features
+            os: ubuntu-22.04-arm
+            args: --all-features
+            toolchain_target: aarch64-unknown-linux-musl
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
 
       - name: Install system dependencies
         run: |
           sudo apt-get install --yes zlib1g-dev libbz2-dev musl musl-dev musl-tools clang libc6-dev
 
-      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: ${{ matrix.args }}
-          use-cross: ${{ matrix.use_cross }}
+        run: |
+          cargo test ${{ matrix.args }}
 
   Testing-MacOS:
     needs: Formatting
@@ -150,27 +142,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1.0.6
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.toolchain }}
-          target: ${{ matrix.toolchain_target }}
+          targets: ${{ matrix.toolchain_target }}
           override: true
-          default: ${{ matrix.default }}
 
       - name: Install htslib dependencies
         run: brew install bzip2 zlib xz curl-openssl
 
       - name: Test
-        uses: actions-rs/cargo@v1.0.1
-        with:
-          use-cross: false # cross is not supported on GHA OSX runner, see: https://github.community/t/why-is-docker-not-installed-on-macos/17017
-          command: test
-          args: --release --all-features --verbose ${{ matrix.aux_args }}
+        run: |
+          cargo test --release --all-features --verbose ${{ matrix.aux_args }}
 #  Testing-OSX-MUSL-BigSur:
 #   needs: Formatting
 #   runs-on: macOS-11.0

--- a/src/bam/buffer.rs
+++ b/src/bam/buffer.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn test_buffer() {
-        let reader = bam::IndexedReader::from_path(&"test/test.bam").unwrap();
+        let reader = bam::IndexedReader::from_path("test/test.bam").unwrap();
         let mut buffer = RecordBuffer::new(reader, false);
 
         buffer.fetch(b"CHROMOSOME_I", 1, 5).unwrap();

--- a/src/bam/ext.rs
+++ b/src/bam/ext.rs
@@ -1,4 +1,4 @@
-//// Copyright 2019 Johannes Köster and Florian Finkernagel.
+// Copyright 2019 Johannes Köster and Florian Finkernagel.
 // Licensed under the MIT license (http://opensource.org/licenses/MIT)
 // This file may not be copied, modified, or distributed
 // except according to those terms.

--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -165,7 +165,7 @@ mod tests {
     fn test_push_tag() {
         let mut record = HeaderRecord::new(b"HD");
         record.push_tag(b"X1", 0);
-        record.push_tag(b"X2", &0);
+        record.push_tag(b"X2", 0);
 
         let x = "x".to_string();
         record.push_tag(b"X3", x.as_str());

--- a/src/bam/mod.rs
+++ b/src/bam/mod.rs
@@ -101,7 +101,7 @@ pub trait Read: Sized {
     /// use rust_htslib::errors::Error;
     /// use rust_htslib::bam::{Read, IndexedReader, Record};
     ///
-    /// let mut bam = IndexedReader::from_path(&"test/test.bam").unwrap();
+    /// let mut bam = IndexedReader::from_path("test/test.bam").unwrap();
     /// bam.fetch((0, 1000, 2000)); // reads on tid 0, from 1000bp to 2000bp
     /// let mut record = Record::new();
     /// while let Some(result) = bam.read(&mut record) {
@@ -136,7 +136,7 @@ pub trait Read: Sized {
     /// use rust_htslib::errors::Error;
     /// use rust_htslib::bam::{Read, Reader, Record};
     /// use rust_htslib::htslib; // for BAM_F*
-    /// let mut bam = Reader::from_path(&"test/test.bam").unwrap();
+    /// let mut bam = Reader::from_path("test/test.bam").unwrap();
     ///
     /// for read in
     ///     bam.rc_records()
@@ -231,7 +231,7 @@ pub trait Read: Sized {
     /// ```
     /// use rust_htslib::bam::{Read, Reader};
     /// use hts_sys;
-    /// let mut cram = Reader::from_path(&"test/test_cram.cram").unwrap();
+    /// let mut cram = Reader::from_path("test/test_cram.cram").unwrap();
     /// cram.set_cram_options(hts_sys::hts_fmt_option_CRAM_OPT_REQUIRED_FIELDS,
     ///             hts_sys::sam_fields_SAM_RNAME | hts_sys::sam_fields_SAM_FLAG).unwrap();
     /// ```
@@ -322,7 +322,7 @@ impl Reader {
     /// # Arguments
     ///
     /// * `start` - Optional starting virtual offset to seek to. Throws an error if it is not
-    /// a valid virtual offset.
+    ///   a valid virtual offset.
     ///
     /// * `end` - Read until the virtual offset is less than `end`
     pub fn iter_chunk(&mut self, start: Option<i64>, end: Option<i64>) -> ChunkIterator<'_, Self> {
@@ -361,7 +361,7 @@ impl Read for Reader {
     /// use rust_htslib::errors::Error;
     /// use rust_htslib::bam::{Read, Reader, Record};
     ///
-    /// let mut bam = Reader::from_path(&"test/test.bam")?;
+    /// let mut bam = Reader::from_path("test/test.bam")?;
     /// let mut record = Record::new();
     ///
     /// // Print the TID of each record
@@ -682,7 +682,7 @@ impl IndexedReader {
     /// Example:
     /// ```
     /// use rust_htslib::bam::{IndexedReader, Read};
-    /// let mut bam = IndexedReader::from_path(&"test/test.bam").unwrap();
+    /// let mut bam = IndexedReader::from_path("test/test.bam").unwrap();
     /// bam.fetch(("chrX", 10000, 20000)); // coordinates 10000..20000 on reference named "chrX"
     /// for read in bam.records() {
     ///     println!("read name: {:?}", read.unwrap().qname());
@@ -1121,10 +1121,7 @@ impl Writer {
             );
 
             //println!("{}", str::from_utf8(&header_string).unwrap());
-            let rec = htslib::sam_hdr_parse(
-                ((l_text + 1) as usize).try_into().unwrap(),
-                text as *const c_char,
-            );
+            let rec = htslib::sam_hdr_parse(l_text + 1, text as *const c_char);
 
             (*rec).text = text as *mut c_char;
             (*rec).l_text = l_text;
@@ -1253,7 +1250,7 @@ pub struct Records<'a, R: Read> {
     reader: &'a mut R,
 }
 
-impl<'a, R: Read> Iterator for Records<'a, R> {
+impl<R: Read> Iterator for Records<'_, R> {
     type Item = Result<record::Record>;
 
     fn next(&mut self) -> Option<Result<record::Record>> {
@@ -1275,11 +1272,11 @@ pub struct RcRecords<'a, R: Read> {
     record: Rc<record::Record>,
 }
 
-impl<'a, R: Read> Iterator for RcRecords<'a, R> {
+impl<R: Read> Iterator for RcRecords<'_, R> {
     type Item = Result<Rc<record::Record>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut record = match Rc::get_mut(&mut self.record) {
+        let record = match Rc::get_mut(&mut self.record) {
             //not make_mut, we don't need a clone
             Some(x) => x,
             None => {
@@ -1288,7 +1285,7 @@ impl<'a, R: Read> Iterator for RcRecords<'a, R> {
             }
         };
 
-        match self.reader.read(&mut record) {
+        match self.reader.read(record) {
             None => None,
             Some(Ok(_)) => Some(Ok(Rc::clone(&self.record))),
             Some(Err(err)) => Some(Err(err)),
@@ -1302,7 +1299,7 @@ pub struct ChunkIterator<'a, R: Read> {
     end: Option<i64>,
 }
 
-impl<'a, R: Read> Iterator for ChunkIterator<'a, R> {
+impl<R: Read> Iterator for ChunkIterator<'_, R> {
     type Item = Result<record::Record>;
     fn next(&mut self) -> Option<Result<record::Record>> {
         if let Some(pos) = self.end {
@@ -1392,7 +1389,7 @@ impl HeaderView {
                 header_string.len(),
             );
 
-            let rec = htslib::sam_hdr_parse((l_text + 1), text as *const c_char);
+            let rec = htslib::sam_hdr_parse(l_text + 1, text as *const c_char);
             (*rec).text = text as *mut c_char;
             (*rec).l_text = l_text;
             rec
@@ -1508,13 +1505,14 @@ mod tests {
     use std::path::Path;
     use std::str;
 
-    fn gold() -> (
+    type GoldType = (
         [&'static [u8]; 6],
         [u16; 6],
         [&'static [u8]; 6],
         [&'static [u8]; 6],
         [CigarString; 6],
-    ) {
+    );
+    fn gold() -> GoldType {
         let names = [
             &b"I"[..],
             &b"II.14978392"[..],
@@ -1588,7 +1586,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     #[test]
     fn test_read() {
         let (names, flags, seqs, quals, cigars) = gold();
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
         let del_len = [1, 1, 1, 1, 1, 100000];
 
         for (i, record) in bam.records().enumerate() {
@@ -1625,17 +1623,14 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_seek() {
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
 
         let mut names_by_voffset = HashMap::new();
 
         let mut offset = bam.tell();
         let mut rec = Record::new();
-        loop {
-            match bam.read(&mut rec) {
-                Some(r) => r.expect("error reading bam"),
-                None => break,
-            };
+        while let Some(r) = bam.read(&mut rec) {
+            r.expect("error reading bam");
             let qname = str::from_utf8(rec.qname()).unwrap().to_string();
             println!("{} {}", offset, qname);
             names_by_voffset.insert(offset, qname);
@@ -1645,9 +1640,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
         for (offset, qname) in names_by_voffset.iter() {
             println!("{} {}", offset, qname);
             bam.seek(*offset).unwrap();
-            match bam.read(&mut rec) {
-                Some(r) => r.unwrap(),
-                None => {}
+            if let Some(r) = bam.read(&mut rec) {
+                r.unwrap();
             };
             let rec_qname = str::from_utf8(rec.qname()).unwrap().to_string();
             assert_eq!(qname, &rec_qname);
@@ -1656,7 +1650,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_read_sam_header() {
-        let bam = Reader::from_path(&"test/test.bam").expect("Error opening file.");
+        let bam = Reader::from_path("test/test.bam").expect("Error opening file.");
 
         let true_header = "@SQ\tSN:CHROMOSOME_I\tLN:15072423\n@SQ\tSN:CHROMOSOME_II\tLN:15279345\
              \n@SQ\tSN:CHROMOSOME_III\tLN:13783700\n@SQ\tSN:CHROMOSOME_IV\tLN:17493793\n@SQ\t\
@@ -1717,7 +1711,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             .expect("Expected successful fetch.");
         assert!(bam.records().count() == 6);
         // using &str and exercising some of the coordinate conversion funcs
-        bam.fetch((str::from_utf8(sq_1).unwrap(), 0 as u32, 2 as u64))
+        bam.fetch((str::from_utf8(sq_1).unwrap(), 0_u32, 2_u64))
             .expect("Expected successful fetch.");
         assert!(bam.records().count() == 6);
         // using a slice
@@ -1794,7 +1788,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_read_indexed() {
-        let bam = IndexedReader::from_path(&"test/test.bam").expect("Expected valid index.");
+        let bam = IndexedReader::from_path("test/test.bam").expect("Expected valid index.");
         _test_read_indexed_common(bam);
     }
 
@@ -1925,8 +1919,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let mut _header = Header::new();
         _header.push_record(
             HeaderRecord::new(b"SQ")
-                .push_tag(b"SN", &"1")
-                .push_tag(b"LN", &10000000),
+                .push_tag(b"SN", "1")
+                .push_tag(b"LN", 10000000),
         );
         let header = HeaderView::from_header(&_header);
 
@@ -1941,7 +1935,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_remove_aux() {
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
 
         for record in bam.records() {
             let mut rec = record.expect("Expected valid record");
@@ -1976,8 +1970,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 &bampath,
                 Header::new().push_record(
                     HeaderRecord::new(b"SQ")
-                        .push_tag(b"SN", &"chr1")
-                        .push_tag(b"LN", &15072423),
+                        .push_tag(b"SN", "chr1")
+                        .push_tag(b"LN", 15072423),
                 ),
                 Format::Bam,
             )
@@ -1993,13 +1987,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
         }
 
         {
-            let mut bam = Reader::from_path(&bampath).expect("Error opening file.");
+            let mut bam = Reader::from_path(bampath).expect("Error opening file.");
 
             for i in 0..names.len() {
                 let mut rec = record::Record::new();
-                match bam.read(&mut rec) {
-                    Some(r) => r.expect("Failed to read record."),
-                    None => {}
+                if let Some(r) = bam.read(&mut rec) {
+                    r.expect("Failed to read record.");
                 };
 
                 assert_eq!(rec.qname(), names[i]);
@@ -2028,8 +2021,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
                 &bampath,
                 Header::new().push_record(
                     HeaderRecord::new(b"SQ")
-                        .push_tag(b"SN", &"chr1")
-                        .push_tag(b"LN", &15072423),
+                        .push_tag(b"SN", "chr1")
+                        .push_tag(b"LN", 15072423),
                 ),
                 Format::Bam,
             )
@@ -2048,7 +2041,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         }
 
         {
-            let mut bam = Reader::from_path(&bampath).expect("Error opening file.");
+            let mut bam = Reader::from_path(bampath).expect("Error opening file.");
 
             for (i, _rec) in bam.records().enumerate() {
                 let idx = i % names.len();
@@ -2086,8 +2079,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     &bampath1,
                     Header::new().push_record(
                         HeaderRecord::new(b"SQ")
-                            .push_tag(b"SN", &"chr1")
-                            .push_tag(b"LN", &15072423),
+                            .push_tag(b"SN", "chr1")
+                            .push_tag(b"LN", 15072423),
                     ),
                     Format::Bam,
                 )
@@ -2097,8 +2090,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
                     &bampath2,
                     Header::new().push_record(
                         HeaderRecord::new(b"SQ")
-                            .push_tag(b"SN", &"chr1")
-                            .push_tag(b"LN", &15072423),
+                            .push_tag(b"SN", "chr1")
+                            .push_tag(b"LN", 15072423),
                     ),
                     Format::Bam,
                 )
@@ -2124,8 +2117,8 @@ CCCCCCCCCCCCCCCCCCC"[..],
         {
             let pool = crate::tpool::ThreadPool::new(2).unwrap();
 
-            for p in vec![bampath1, bampath2] {
-                let mut bam = Reader::from_path(&p).expect("Error opening file.");
+            for p in [bampath1, bampath2] {
+                let mut bam = Reader::from_path(p).expect("Error opening file.");
                 bam.set_thread_pool(&pool).unwrap();
 
                 for (i, _rec) in bam.iter_chunk(None, None).enumerate() {
@@ -2158,12 +2151,12 @@ CCCCCCCCCCCCCCCCCCC"[..],
         let bampath = tmp.path().join("test.bam");
         println!("{:?}", bampath);
 
-        let mut input_bam = Reader::from_path(&"test/test.bam").expect("Error opening file.");
+        let mut input_bam = Reader::from_path("test/test.bam").expect("Error opening file.");
 
         {
             let mut bam = Writer::from_path(
                 &bampath,
-                &Header::from_template(&input_bam.header()),
+                &Header::from_template(input_bam.header()),
                 Format::Bam,
             )
             .expect("Error opening file.");
@@ -2174,7 +2167,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         }
 
         {
-            let copy_bam = Reader::from_path(&bampath).expect("Error opening file.");
+            let copy_bam = Reader::from_path(bampath).expect("Error opening file.");
 
             // Verify that the header came across correctly
             assert_eq!(input_bam.header().as_bytes(), copy_bam.header().as_bytes());
@@ -2187,7 +2180,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_pileup() {
         let (_, _, seqs, quals, _) = gold();
 
-        let mut bam = Reader::from_path(&"test/test.bam").expect("Error opening file.");
+        let mut bam = Reader::from_path("test/test.bam").expect("Error opening file.");
         let pileups = bam.pileup();
         for pileup in pileups.take(26) {
             let _pileup = pileup.expect("Expected successful pileup.");
@@ -2206,7 +2199,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
 
     #[test]
     fn test_idx_pileup() {
-        let mut bam = IndexedReader::from_path(&"test/test.bam").expect("Error opening file.");
+        let mut bam = IndexedReader::from_path("test/test.bam").expect("Error opening file.");
         // read without fetch
         for pileup in bam.pileup() {
             pileup.unwrap();
@@ -2250,7 +2243,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         // test the cached and uncached ways of getting the cigar string.
 
         let (_, _, _, _, cigars) = gold();
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
 
         for (i, record) in bam.records().enumerate() {
             let rec = record.expect("Expected valid record");
@@ -2309,29 +2302,29 @@ CCCCCCCCCCCCCCCCCCC"[..],
             let mut header = Header::new();
             header.push_record(
                 HeaderRecord::new(b"HD")
-                    .push_tag(b"VN", &"1.5")
-                    .push_tag(b"SO", &"coordinate"),
+                    .push_tag(b"VN", "1.5")
+                    .push_tag(b"SO", "coordinate"),
             );
             header.push_record(
                 HeaderRecord::new(b"SQ")
-                    .push_tag(b"SN", &"chr1")
-                    .push_tag(b"LN", &120)
-                    .push_tag(b"M5", &"20a9a0fb770814e6c5e49946750f9724")
-                    .push_tag(b"UR", &"test/test_cram.fa"),
+                    .push_tag(b"SN", "chr1")
+                    .push_tag(b"LN", 120)
+                    .push_tag(b"M5", "20a9a0fb770814e6c5e49946750f9724")
+                    .push_tag(b"UR", "test/test_cram.fa"),
             );
             header.push_record(
                 HeaderRecord::new(b"SQ")
-                    .push_tag(b"SN", &"chr2")
-                    .push_tag(b"LN", &120)
-                    .push_tag(b"M5", &"7a2006ccca94ea92b6dae5997e1b0d70")
-                    .push_tag(b"UR", &"test/test_cram.fa"),
+                    .push_tag(b"SN", "chr2")
+                    .push_tag(b"LN", 120)
+                    .push_tag(b"M5", "7a2006ccca94ea92b6dae5997e1b0d70")
+                    .push_tag(b"UR", "test/test_cram.fa"),
             );
             header.push_record(
                 HeaderRecord::new(b"SQ")
-                    .push_tag(b"SN", &"chr3")
-                    .push_tag(b"LN", &120)
-                    .push_tag(b"M5", &"a66b336bfe3ee8801c744c9545c87e24")
-                    .push_tag(b"UR", &"test/test_cram.fa"),
+                    .push_tag(b"SN", "chr3")
+                    .push_tag(b"LN", 120)
+                    .push_tag(b"M5", "a66b336bfe3ee8801c744c9545c87e24")
+                    .push_tag(b"UR", "test/test_cram.fa"),
             );
 
             let mut cram_writer = Writer::from_path(&cram_path, &header, Format::Cram)
@@ -2341,7 +2334,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // Write BAM records to CRAM file
             for rec in bam_records.iter() {
                 cram_writer
-                    .write(&rec)
+                    .write(rec)
                     .expect("Faied to write record to CRAM.");
             }
         }
@@ -2395,7 +2388,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
             .map(|level| {
                 let output_bam_path = tmp.path().join("test.bam");
                 {
-                    let mut reader = Reader::from_path(&input_bam_path).unwrap();
+                    let mut reader = Reader::from_path(input_bam_path).unwrap();
                     let header = Header::from_template(reader.header());
                     let mut writer =
                         Writer::from_path(&output_bam_path, &header, Format::Bam).unwrap();
@@ -2508,7 +2501,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     #[test]
     fn test_rc_records() {
         let (names, flags, seqs, quals, cigars) = gold();
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
         let del_len = [1, 1, 1, 1, 1, 100000];
 
         for (i, record) in bam.rc_records().enumerate() {
@@ -2549,18 +2542,18 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_aux_arrays() {
         let bam_header = Header::new();
         let mut test_record = Record::from_sam(
-            &mut HeaderView::from_header(&bam_header),
+            &HeaderView::from_header(&bam_header),
             "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
         )
         .unwrap();
 
-        let array_i8: Vec<i8> = vec![std::i8::MIN, -1, 0, 1, std::i8::MAX];
-        let array_u8: Vec<u8> = vec![std::u8::MIN, 0, 1, std::u8::MAX];
-        let array_i16: Vec<i16> = vec![std::i16::MIN, -1, 0, 1, std::i16::MAX];
-        let array_u16: Vec<u16> = vec![std::u16::MIN, 0, 1, std::u16::MAX];
-        let array_i32: Vec<i32> = vec![std::i32::MIN, -1, 0, 1, std::i32::MAX];
-        let array_u32: Vec<u32> = vec![std::u32::MIN, 0, 1, std::u32::MAX];
-        let array_f32: Vec<f32> = vec![std::f32::MIN, 0.0, -0.0, 0.1, 0.99, std::f32::MAX];
+        let array_i8: Vec<i8> = vec![i8::MIN, -1, 0, 1, i8::MAX];
+        let array_u8: Vec<u8> = vec![u8::MIN, 0, 1, u8::MAX];
+        let array_i16: Vec<i16> = vec![i16::MIN, -1, 0, 1, i16::MAX];
+        let array_u16: Vec<u16> = vec![u16::MIN, 0, 1, u16::MAX];
+        let array_i32: Vec<i32> = vec![i32::MIN, -1, 0, 1, i32::MAX];
+        let array_u32: Vec<u32> = vec![u32::MIN, 0, 1, u32::MAX];
+        let array_f32: Vec<f32> = vec![f32::MIN, 0.0, -0.0, 0.1, 0.99, f32::MAX];
 
         test_record
             .push_aux(b"XA", Aux::ArrayI8((&array_i8).into()))
@@ -2880,7 +2873,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
     fn test_aux_scalars() {
         let bam_header = Header::new();
         let mut test_record = Record::from_sam(
-            &mut HeaderView::from_header(&bam_header),
+            &HeaderView::from_header(&bam_header),
             "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
         )
         .unwrap();
@@ -2953,7 +2946,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         // Raw bytes
         let bam_header = Header::new();
         let mut test_record = Record::from_sam(
-            &mut HeaderView::from_header(&bam_header),
+            &HeaderView::from_header(&bam_header),
             "ali1\t4\t*\t0\t0\t*\t*\t0\t0\tACGT\tFFFF".as_bytes(),
         )
         .unwrap();
@@ -3019,15 +3012,15 @@ CCCCCCCCCCCCCCCCCCC"[..],
             // Add the version
             header.push_record(
                 HeaderRecord::new(b"HD")
-                    .push_tag(b"VN", &"1.6")
-                    .push_tag(b"SO", &"unsorted"),
+                    .push_tag(b"VN", "1.6")
+                    .push_tag(b"SO", "unsorted"),
             );
 
             // Build the writer
             let mut writer = Writer::from_path(&bampath, &header, Format::Bam).unwrap();
 
             // Build an empty record
-            let mut record = Record::new();
+            let record = Record::new();
 
             // Write the record (this previously seg-faulted)
             assert!(writer.write(&record).is_ok());
@@ -3036,7 +3029,7 @@ CCCCCCCCCCCCCCCCCCC"[..],
         // Read the record
         {
             // Build th reader
-            let mut reader = Reader::from_path(&bampath).expect("Error opening file.");
+            let mut reader = Reader::from_path(bampath).expect("Error opening file.");
 
             // Read the record
             let mut rec = Record::new();

--- a/src/bam/pileup.rs
+++ b/src/bam/pileup.rs
@@ -60,7 +60,7 @@ pub struct Alignment<'a> {
     inner: &'a htslib::bam_pileup1_t,
 }
 
-impl<'a> fmt::Debug for Alignment<'a> {
+impl fmt::Debug for Alignment<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Alignment")
     }
@@ -137,12 +137,12 @@ impl<'a, R: bam::Read> Pileups<'a, R> {
     }
 
     /// Warning: because htslib internally uses signed integer for depth this method
-    /// will panic if `depth` exceeds `i32::max_value()`.
+    /// will panic if `depth` exceeds `i32::MAX`.
     pub fn set_max_depth(&mut self, depth: u32) {
-        if depth > i32::max_value() as u32 {
+        if depth > i32::MAX as u32 {
             panic!(
                 "Maximum value for pileup depth is {} but {} was provided",
-                i32::max_value(),
+                i32::MAX,
                 depth
             )
         }
@@ -153,7 +153,7 @@ impl<'a, R: bam::Read> Pileups<'a, R> {
     }
 }
 
-impl<'a, R: bam::Read> Iterator for Pileups<'a, R> {
+impl<R: bam::Read> Iterator for Pileups<'_, R> {
     type Item = Result<Pileup>;
 
     #[allow(clippy::match_bool)]
@@ -174,7 +174,7 @@ impl<'a, R: bam::Read> Iterator for Pileups<'a, R> {
     }
 }
 
-impl<'a, R: bam::Read> Drop for Pileups<'a, R> {
+impl<R: bam::Read> Drop for Pileups<'_, R> {
     fn drop(&mut self) {
         unsafe {
             htslib::bam_plp_reset(self.itr);
@@ -191,7 +191,7 @@ mod tests {
 
     #[test]
     fn test_max_pileup() {
-        let mut bam = bam::Reader::from_path(&"test/test.bam").unwrap();
+        let mut bam = bam::Reader::from_path("test/test.bam").unwrap();
         let mut p = bam.pileup();
         p.set_max_depth(0u32);
         p.set_max_depth(800u32);
@@ -200,8 +200,8 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_max_pileup_to_high() {
-        let mut bam = bam::Reader::from_path(&"test/test.bam").unwrap();
+        let mut bam = bam::Reader::from_path("test/test.bam").unwrap();
         let mut p = bam.pileup();
-        p.set_max_depth((i32::max_value() as u32) + 1);
+        p.set_max_depth((i32::MAX as u32) + 1);
     }
 }

--- a/src/bam/record_serde.rs
+++ b/src/bam/record_serde.rs
@@ -64,7 +64,7 @@ impl<'de> Deserialize<'de> for Record {
             {
                 struct FieldVisitor;
 
-                impl<'de> Visitor<'de> for FieldVisitor {
+                impl Visitor<'_> for FieldVisitor {
                     type Value = Field;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_bincode() {
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
 
         let mut recs = Vec::new();
         for record in bam.records() {
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_serde_json() {
-        let mut bam = Reader::from_path(&Path::new("test/test.bam")).expect("Error opening file.");
+        let mut bam = Reader::from_path(Path::new("test/test.bam")).expect("Error opening file.");
 
         let mut recs = Vec::new();
         for record in bam.records() {

--- a/src/bcf/buffer.rs
+++ b/src/bcf/buffer.rs
@@ -192,7 +192,7 @@ mod tests {
 
     #[test]
     fn test_buffer() {
-        let reader = bcf::Reader::from_path(&"test/test.bcf").unwrap();
+        let reader = bcf::Reader::from_path("test/test.bcf").unwrap();
         let mut buffer = RecordBuffer::new(reader);
 
         buffer.fetch(b"1", 100, 10023).unwrap();

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -113,12 +113,14 @@ impl Header {
             .map(|&s| ffi::CString::new(s).unwrap())
             .collect();
         let name_pointers: Vec<_> = names.iter().map(|s| s.as_ptr() as *mut i8).collect();
+        #[allow(clippy::unnecessary_cast)]
+        let name_pointers_ptr = name_pointers.as_ptr() as *const *mut c_char;
         let inner = unsafe {
             htslib::bcf_hdr_subset(
                 header.inner,
                 samples.len() as i32,
-                name_pointers.as_ptr() as *const *mut c_char,
-                imap.as_mut_ptr() as *mut i32,
+                name_pointers_ptr,
+                imap.as_mut_ptr(),
             )
         };
         if inner.is_null() {
@@ -551,7 +553,6 @@ pub enum TagLength {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::bcf::Reader;
 
     #[test]

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -321,7 +321,7 @@ impl IndexedReader {
     ///           contig name to ID.
     /// * `start` - `0`-based **inclusive** start coordinate of region on reference.
     /// * `end` - Optional `0`-based **inclusive** end coordinate of region on reference. If `None`
-    /// is given, records are fetched from `start` until the end of the contig.
+    ///   is given, records are fetched from `start` until the end of the contig.
     ///
     /// # Note
     /// The entire contig can be fetched by setting `start` to `0` and `end` to `None`.
@@ -796,7 +796,7 @@ pub struct Records<'a, R: Read> {
     reader: &'a mut R,
 }
 
-impl<'a, R: Read> Iterator for Records<'a, R> {
+impl<R: Read> Iterator for Records<'_, R> {
     type Item = Result<record::Record>;
 
     fn next(&mut self) -> Option<Result<record::Record>> {
@@ -857,7 +857,7 @@ mod tests {
 
             assert_eq!(record.rid().expect("Error reading rid."), 0);
             assert_eq!(record.pos(), 10021 + i as i64);
-            assert!((record.qual() - 0f32).abs() < std::f32::EPSILON);
+            assert!((record.qual() - 0f32).abs() < f32::EPSILON);
             let mut buffer = Buffer::new();
             assert!(
                 (record
@@ -867,7 +867,7 @@ mod tests {
                     .expect("Missing tag")[0]
                     - 1.0)
                     .abs()
-                    < std::f32::EPSILON
+                    < f32::EPSILON
             );
             if i == 59 {
                 assert!(
@@ -878,7 +878,7 @@ mod tests {
                         .expect("Missing tag")[0]
                         - -0.379885)
                         .abs()
-                        < std::f32::EPSILON
+                        < f32::EPSILON
                 );
             }
             // the artificial "not observed" allele is present in each record.
@@ -925,7 +925,7 @@ mod tests {
 
     #[test]
     fn test_fetch() {
-        let mut bcf = IndexedReader::from_path(&"test/test.bcf").expect("Error opening file.");
+        let mut bcf = IndexedReader::from_path("test/test.bcf").expect("Error opening file.");
         bcf.set_threads(2).unwrap();
         let rid = bcf
             .header()
@@ -938,7 +938,7 @@ mod tests {
 
     #[test]
     fn test_fetch_all() {
-        let mut bcf = IndexedReader::from_path(&"test/test.bcf").expect("Error opening file.");
+        let mut bcf = IndexedReader::from_path("test/test.bcf").expect("Error opening file.");
         bcf.set_threads(2).unwrap();
         let rid = bcf
             .header()
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn test_fetch_open_ended() {
-        let mut bcf = IndexedReader::from_path(&"test/test.bcf").expect("Error opening file.");
+        let mut bcf = IndexedReader::from_path("test/test.bcf").expect("Error opening file.");
         bcf.set_threads(2).unwrap();
         let rid = bcf
             .header()
@@ -962,7 +962,7 @@ mod tests {
 
     #[test]
     fn test_fetch_start_greater_than_last_vcf_pos() {
-        let mut bcf = IndexedReader::from_path(&"test/test.bcf").expect("Error opening file.");
+        let mut bcf = IndexedReader::from_path("test/test.bcf").expect("Error opening file.");
         bcf.set_threads(2).unwrap();
         let rid = bcf
             .header()
@@ -974,7 +974,7 @@ mod tests {
 
     #[test]
     fn test_write() {
-        let mut bcf = Reader::from_path(&"test/test_multi.bcf").expect("Error opening file.");
+        let mut bcf = Reader::from_path("test/test_multi.bcf").expect("Error opening file.");
         let tmp = tempfile::Builder::new()
             .prefix("rust-htslib")
             .tempdir()
@@ -1002,7 +1002,7 @@ mod tests {
 
     #[test]
     fn test_strings() {
-        let mut vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
+        let mut vcf = Reader::from_path("test/test_string.vcf").expect("Error opening file.");
         let fs1 = [
             &b"LongString1"[..],
             &b"LongString2"[..],
@@ -1041,7 +1041,7 @@ mod tests {
 
     #[test]
     fn test_missing() {
-        let mut vcf = Reader::from_path(&"test/test_missing.vcf").expect("Error opening file.");
+        let mut vcf = Reader::from_path("test/test_missing.vcf").expect("Error opening file.");
         let fn4 = [
             &[
                 i32::missing(),
@@ -1081,7 +1081,7 @@ mod tests {
 
     #[test]
     fn test_genotypes() {
-        let mut vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
+        let mut vcf = Reader::from_path("test/test_string.vcf").expect("Error opening file.");
         let expected = ["./1", "1|1", "0/1", "0|1", "1|.", "1/1"];
         for (rec, exp_gt) in vcf.records().zip(expected.iter()) {
             let rec = rec.expect("Error reading record.");
@@ -1092,7 +1092,7 @@ mod tests {
 
     #[test]
     fn test_header_ids() {
-        let vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_string.vcf").expect("Error opening file.");
         let header = &vcf.header();
         use crate::bcf::header::Id;
 
@@ -1103,7 +1103,7 @@ mod tests {
 
     #[test]
     fn test_header_samples() {
-        let vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_string.vcf").expect("Error opening file.");
         let header = &vcf.header();
 
         assert_eq!(header.id_to_sample(Id(0)), b"one");
@@ -1115,7 +1115,7 @@ mod tests {
 
     #[test]
     fn test_header_contigs() {
-        let vcf = Reader::from_path(&"test/test_multi.bcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_multi.bcf").expect("Error opening file.");
         let header = &vcf.header();
 
         assert_eq!(header.contig_count(), 86);
@@ -1134,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_header_records() {
-        let vcf = Reader::from_path(&"test/test_string.vcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_string.vcf").expect("Error opening file.");
         let records = vcf.header().header_records();
         assert_eq!(records.len(), 10);
 
@@ -1154,7 +1154,7 @@ mod tests {
 
     #[test]
     fn test_header_info_types() {
-        let vcf = Reader::from_path(&"test/test.bcf").unwrap();
+        let vcf = Reader::from_path("test/test.bcf").unwrap();
         let header = vcf.header();
         let truth = vec![
             (
@@ -1188,7 +1188,7 @@ mod tests {
             assert_eq!(tag_length, ref_length);
         }
 
-        let vcf = Reader::from_path(&"test/test_svlen.vcf").unwrap();
+        let vcf = Reader::from_path("test/test_svlen.vcf").unwrap();
         let header = vcf.header();
         let truth = vec![
             (
@@ -1227,7 +1227,7 @@ mod tests {
 
     #[test]
     fn test_remove_alleles() {
-        let mut bcf = Reader::from_path(&"test/test_multi.bcf").unwrap();
+        let mut bcf = Reader::from_path("test/test_multi.bcf").unwrap();
         for res in bcf.records() {
             let mut record = res.unwrap();
             if record.pos() == 10080 {
@@ -1259,13 +1259,13 @@ mod tests {
             .expect("Cannot create temp dir");
         let out_path = tmp.path().join("test_various.out.vcf");
 
-        let vcf = Reader::from_path(&"test/test_various.vcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_various.vcf").expect("Error opening file.");
         // The writer goes into its own block so we can ensure that the file is closed and
         // all data is written below.
         {
             let mut writer = Writer::from_path(
                 &out_path,
-                &Header::from_template(&vcf.header()),
+                &Header::from_template(vcf.header()),
                 true,
                 Format::Vcf,
             )
@@ -1337,7 +1337,7 @@ mod tests {
 
     #[test]
     fn test_remove_headers() {
-        let vcf = Reader::from_path(&"test/test_headers.vcf").expect("Error opening file.");
+        let vcf = Reader::from_path("test/test_headers.vcf").expect("Error opening file.");
         let tmp = tempfile::Builder::new()
             .prefix("rust-htslib")
             .tempdir()
@@ -1369,8 +1369,8 @@ mod tests {
         reader.set_pairing(synced::pairing::SNPS);
 
         assert_eq!(reader.reader_count(), 0);
-        reader.add_reader(&"test/test_left.vcf.gz").unwrap();
-        reader.add_reader(&"test/test_right.vcf.gz").unwrap();
+        reader.add_reader("test/test_left.vcf.gz").unwrap();
+        reader.add_reader("test/test_right.vcf.gz").unwrap();
         assert_eq!(reader.reader_count(), 2);
 
         let res1 = reader.read_next();
@@ -1399,8 +1399,8 @@ mod tests {
         reader.set_pairing(synced::pairing::SNPS);
 
         assert_eq!(reader.reader_count(), 0);
-        reader.add_reader(&"test/test_left.vcf.gz").unwrap();
-        reader.add_reader(&"test/test_right.vcf.gz").unwrap();
+        reader.add_reader("test/test_left.vcf.gz").unwrap();
+        reader.add_reader("test/test_right.vcf.gz").unwrap();
         assert_eq!(reader.reader_count(), 2);
 
         reader.fetch(0, 0, 1000).unwrap();

--- a/src/bgzf/mod.rs
+++ b/src/bgzf/mod.rs
@@ -87,7 +87,7 @@ impl Reader {
         let mode = ffi::CString::new("r").unwrap();
         let cpath = ffi::CString::new(path).unwrap();
         let inner = unsafe { htslib::bgzf_open(cpath.as_ptr(), mode.as_ptr()) };
-        if inner != std::ptr::null_mut() {
+        if !inner.is_null() {
             Ok(Self { inner })
         } else {
             Err(Error::FileOpen {
@@ -217,7 +217,7 @@ impl Writer {
         let mode = Self::get_open_mode(level)?;
         let cpath = ffi::CString::new(path).unwrap();
         let inner = unsafe { htslib::bgzf_open(cpath.as_ptr(), mode.as_ptr()) };
-        if inner != std::ptr::null_mut() {
+        if !inner.is_null() {
             Ok(Self { inner, tpool: None })
         } else {
             Err(Error::FileOpen {
@@ -240,7 +240,7 @@ impl Writer {
             // This should be unreachable
             Ok(i) => return Err(Error::BgzfInvalidCompressionLevel { level: i }),
         };
-        return Ok(ffi::CString::new(write_string).unwrap());
+        Ok(ffi::CString::new(write_string).unwrap())
     }
 
     /// Set the thread pool to use for parallel compression.
@@ -514,7 +514,7 @@ mod tests {
             CompressionLevel::Uncompressed,
         ]
         .into_iter()
-        .chain((-1..=9_i8).map(|n| CompressionLevel::Level(n)));
+        .chain((-1..=9_i8).map(CompressionLevel::Level));
 
         for level in compression_levels {
             {

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -86,10 +86,10 @@ impl Reader {
     /// * `begin` - the offset within the template sequence (starting with 0)
     /// * `end` - the end position to return (if smaller than `begin`, the behavior is undefined).
     pub fn fetch_seq<N: AsRef<str>>(&self, name: N, begin: usize, end: usize) -> Result<Vec<u8>> {
-        if begin > std::i64::MAX as usize {
+        if begin > i64::MAX as usize {
             return Err(Error::FaidxPositionTooLarge);
         }
-        if end > std::i64::MAX as usize {
+        if end > i64::MAX as usize {
             return Err(Error::FaidxPositionTooLarge);
         }
         let cname = ffi::CString::new(name.as_ref().as_bytes()).unwrap();

--- a/src/tbx/mod.rs
+++ b/src/tbx/mod.rs
@@ -253,6 +253,10 @@ impl Reader {
             Ok(())
         }
     }
+
+    pub fn hts_format(&self) -> htslib::htsExactFormat {
+        self.hts_format
+    }
 }
 
 /// Return whether the two given genomic intervals overlap.
@@ -327,7 +331,7 @@ pub struct Records<'a, R: Read> {
     reader: &'a mut R,
 }
 
-impl<'a, R: Read> Iterator for Records<'a, R> {
+impl<R: Read> Iterator for Records<'_, R> {
     type Item = Result<Vec<u8>>;
 
     #[allow(clippy::read_zero_byte_vec)]

--- a/src/tpool.rs
+++ b/src/tpool.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::sync::Arc;
+use std::rc::Rc;
 
 pub use crate::errors::{Error, Result};
 use crate::htslib;
@@ -11,7 +11,7 @@ use crate::htslib;
 /// explicitly manage the lifetime of the `ThreadPool`.
 #[derive(Clone, Debug)]
 pub struct ThreadPool {
-    pub(crate) handle: Arc<RefCell<InnerThreadPool>>,
+    pub(crate) handle: Rc<RefCell<InnerThreadPool>>,
 }
 
 impl ThreadPool {
@@ -30,7 +30,7 @@ impl ThreadPool {
             };
             let inner = InnerThreadPool { inner };
 
-            let handle = Arc::new(RefCell::new(inner));
+            let handle = Rc::new(RefCell::new(inner));
             Ok(ThreadPool { handle })
         }
     }


### PR DESCRIPTION
* replace the not maintained `actions-rs/toolchain` action with `dtolnay/rust-toolchain`
* replace `actions-rs/cargo` with direct usage of `cargo`
* * replace `actions-rs/clippy` with direct usage of `cargo clippy` (it even shows that there are some problems in the code)
* add build on Linux ARM64. Often Bioconda recipes fail to build on linux-aarch64 because they use a version of rust-htslib that has/had problems for this platform