### PR TITLE
Adding `from_hashmap` for bam Header

### DIFF
--- a/src/bam/header.rs
+++ b/src/bam/header.rs
@@ -48,6 +48,21 @@ impl Header {
         }
     }
 
+    /// Creates a new Header from a HashMap. Useful if you have used `to_hashmap` and manipulated that hashmap to create a new header.
+    pub fn from_hashmap(hashmap: HashMap<String, Vec<LinearMap<String, String>>>) -> Self {
+        let mut header = Header::new();
+        for (key, values) in hashmap.iter() {
+            for value in values {
+                let mut record = HeaderRecord::new(key.as_bytes());
+                for (tag, val) in value.iter() {
+                    record.push_tag(tag.as_bytes(), val);
+                }
+                header.push_record(&record);
+            }
+        }
+        header
+    }
+
     /// Add a record to the header.
     pub fn push_record(&mut self, record: &HeaderRecord<'_>) -> &mut Self {
         self.records.push(record.to_bytes());


### PR DESCRIPTION
Hi there, 

For bam headers I often want to take the results from `bam:Header:to_hashmap` manipulate it and create a new header from that hashmap. This is a simple PR that adds a `from_hashmap` function that allows this.

Cheers,
Mitchell
 