### PR TITLE
Reason about Send/Sync-ness of types and change Rcs to Arcs

### DIFF
--- a/src/bam/record.rs
+++ b/src/bam/record.rs
@@ -11,9 +11,9 @@ use std::marker::PhantomData;
 use std::mem::{size_of, MaybeUninit};
 use std::ops;
 use std::os::raw::c_char;
-use std::rc::Rc;
 use std::slice;
 use std::str;
+use std::sync::Arc;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
@@ -53,7 +53,7 @@ pub struct Record {
     pub inner: htslib::bam1_t,
     own: bool,
     cigar: Option<CigarStringView>,
-    header: Option<Rc<HeaderView>>,
+    header: Option<Arc<HeaderView>>,
 }
 
 unsafe impl Send for Record {}
@@ -183,7 +183,7 @@ impl Record {
         }
     }
 
-    pub fn set_header(&mut self, header: Rc<HeaderView>) {
+    pub fn set_header(&mut self, header: Arc<HeaderView>) {
         self.header = Some(header);
     }
 

--- a/src/bcf/header.rs
+++ b/src/bcf/header.rs
@@ -34,9 +34,9 @@
 
 use std::ffi;
 use std::os::raw::c_char;
-use std::rc::Rc;
 use std::slice;
 use std::str;
+use std::sync::Arc;
 
 use crate::htslib;
 
@@ -65,9 +65,12 @@ custom_derive! {
 /// A BCF header.
 #[derive(Debug)]
 pub struct Header {
-    pub inner: *mut htslib::bcf_hdr_t,
+    pub(crate) inner: *mut htslib::bcf_hdr_t,
     pub subset: Option<SampleSubset>,
 }
+
+unsafe impl Send for Header {}
+unsafe impl Sync for Header {}
 
 impl Default for Header {
     fn default() -> Self {
@@ -266,11 +269,14 @@ pub enum HeaderRecord {
 
 #[derive(Debug)]
 pub struct HeaderView {
-    pub inner: *mut htslib::bcf_hdr_t,
+    pub(crate) inner: *mut htslib::bcf_hdr_t,
 }
 
+unsafe impl Send for HeaderView {}
+unsafe impl Sync for HeaderView {}
+
 impl HeaderView {
-    pub fn new(inner: *mut htslib::bcf_hdr_t) -> Self {
+    pub(crate) fn new(inner: *mut htslib::bcf_hdr_t) -> Self {
         HeaderView { inner }
     }
 
@@ -513,8 +519,15 @@ impl HeaderView {
     /// Create an empty record using this header view.
     ///
     /// The record can be reused multiple times.
+    ///
+    /// # Performance
+    ///
+    /// This is quite slow and resource-intensive as it clones the actual
+    /// header, instead of the reference to it. Therefore, whenever possible
+    /// / feasible you should use [`Record::new`](crate::bcf::Record::new) with
+    /// a reference to your header.
     pub fn empty_record(&self) -> crate::bcf::Record {
-        crate::bcf::Record::new(Rc::new(self.clone()))
+        crate::bcf::Record::new(Arc::new(self.clone()))
     }
 }
 

--- a/src/bcf/mod.rs
+++ b/src/bcf/mod.rs
@@ -105,8 +105,8 @@
 
 use std::ffi;
 use std::path::Path;
-use std::rc::Rc;
 use std::str;
+use std::sync::Arc;
 
 use url::Url;
 
@@ -159,10 +159,11 @@ pub trait Read: Sized {
 #[derive(Debug)]
 pub struct Reader {
     inner: *mut htslib::htsFile,
-    header: Rc<HeaderView>,
+    header: Arc<HeaderView>,
 }
 
 unsafe impl Send for Reader {}
+
 /// # Safety
 ///
 /// Implementation for `Reader::set_threads()` and `Writer::set_threads`.
@@ -202,7 +203,7 @@ impl Reader {
         let header = unsafe { htslib::bcf_hdr_read(htsfile) };
         Ok(Reader {
             inner: htsfile,
-            header: Rc::new(HeaderView::new(header)),
+            header: Arc::new(HeaderView::new(header)),
         })
     }
 }
@@ -215,7 +216,7 @@ impl Read for Reader {
                     // Always unpack record.
                     htslib::bcf_unpack(record.inner_mut(), htslib::BCF_UN_ALL as i32);
                 }
-                record.set_header(Rc::clone(&self.header));
+                record.set_header(Arc::clone(&self.header));
                 Some(Ok(()))
             }
             -1 => None,
@@ -224,7 +225,7 @@ impl Read for Reader {
     }
 
     fn records(&mut self) -> Records<'_, Self> {
-        Records { reader: self }
+        Records::new(self)
     }
 
     fn set_threads(&mut self, n_threads: usize) -> Result<()> {
@@ -237,7 +238,7 @@ impl Read for Reader {
 
     /// Return empty record.  Can be reused multiple times.
     fn empty_record(&self) -> Record {
-        self.header.empty_record()
+        Record::new(self.header.clone())
     }
 }
 
@@ -255,7 +256,7 @@ pub struct IndexedReader {
     /// The synced VCF/BCF reader to use internally.
     inner: *mut htslib::bcf_srs_t,
     /// The header.
-    header: Rc<HeaderView>,
+    header: Arc<HeaderView>,
 
     /// The position of the previous fetch, if any.
     current_region: Option<(u32, u64, Option<u64>)>,
@@ -298,7 +299,7 @@ impl IndexedReader {
         } // 0: BCF_SR_REQUIRE_IDX
           // Attach a file with the path from the arguments.
         if unsafe { htslib::bcf_sr_add_reader(ser_reader, path.as_ptr()) } >= 0 {
-            let header = Rc::new(HeaderView::new(unsafe {
+            let header = Arc::new(HeaderView::new(unsafe {
                 htslib::bcf_hdr_dup((*(*ser_reader).readers.offset(0)).header)
             }));
             Ok(IndexedReader {
@@ -368,7 +369,7 @@ impl Read for IndexedReader {
                     htslib::bcf_unpack(record.inner_mut(), htslib::BCF_UN_ALL as i32);
                 }
 
-                record.set_header(Rc::clone(&self.header));
+                record.set_header(Arc::clone(&self.header));
 
                 match self.current_region {
                     Some((rid, _start, end)) => {
@@ -389,7 +390,7 @@ impl Read for IndexedReader {
     }
 
     fn records(&mut self) -> Records<'_, Self> {
-        Records { reader: self }
+        Records::new(self)
     }
 
     fn set_threads(&mut self, n_threads: usize) -> Result<()> {
@@ -408,7 +409,7 @@ impl Read for IndexedReader {
     }
 
     fn empty_record(&self) -> Record {
-        Record::new(Rc::clone(&self.header))
+        Record::new(self.header.clone())
     }
 }
 
@@ -451,8 +452,8 @@ pub mod synced {
         /// Internal handle for the synced reader.
         inner: *mut crate::htslib::bcf_srs_t,
 
-        /// RC's of `HeaderView`s of the readers.
-        headers: Vec<Rc<HeaderView>>,
+        /// Arcs of `HeaderView`s of the readers.
+        headers: Vec<Arc<HeaderView>>,
 
         /// The position of the previous fetch, if any.
         current_region: Option<(u32, u64, u64)>,
@@ -503,7 +504,7 @@ pub mod synced {
                     }
 
                     let i = (self.reader_count() - 1) as isize;
-                    let header = Rc::new(HeaderView::new(unsafe {
+                    let header = Arc::new(HeaderView::new(unsafe {
                         crate::htslib::bcf_hdr_dup((*(*self.inner).readers.offset(i)).header)
                     }));
                     self.headers.push(header);
@@ -642,7 +643,7 @@ pub enum Format {
 #[derive(Debug)]
 pub struct Writer {
     inner: *mut htslib::htsFile,
-    header: Rc<HeaderView>,
+    header: Arc<HeaderView>,
     subset: Option<SampleSubset>,
 }
 
@@ -710,7 +711,7 @@ impl Writer {
         unsafe { htslib::bcf_hdr_write(htsfile, header.inner) };
         Ok(Writer {
             inner: htsfile,
-            header: Rc::new(HeaderView::new(unsafe {
+            header: Arc::new(HeaderView::new(unsafe {
                 htslib::bcf_hdr_dup(header.inner)
             })),
             subset: header.subset.clone(),
@@ -726,7 +727,7 @@ impl Writer {
     ///
     /// This record can then be reused multiple times.
     pub fn empty_record(&self) -> Record {
-        record::Record::new(Rc::clone(&self.header))
+        Record::new(self.header.clone())
     }
 
     /// Translate record to header of this writer.
@@ -738,7 +739,7 @@ impl Writer {
         unsafe {
             htslib::bcf_translate(self.header.inner, record.header().inner, record.inner);
         }
-        record.set_header(Rc::clone(&self.header));
+        record.set_header(Arc::clone(&self.header));
     }
 
     /// Subset samples of record to match header of this writer.
@@ -794,6 +795,12 @@ impl Drop for Writer {
 #[derive(Debug)]
 pub struct Records<'a, R: Read> {
     reader: &'a mut R,
+}
+
+impl<'a, R: Read> Records<'a, R> {
+    pub fn new(reader: &'a mut R) -> Self {
+        Self { reader }
+    }
 }
 
 impl<R: Read> Iterator for Records<'_, R> {

--- a/src/bcf/record.rs
+++ b/src/bcf/record.rs
@@ -9,9 +9,9 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::os::raw::c_char;
 use std::ptr;
-use std::rc::Rc;
 use std::slice;
 use std::str;
+use std::sync::Arc;
 use std::{ffi, iter};
 
 use bio_types::genome;
@@ -175,12 +175,12 @@ impl<'a, T: 'a + fmt::Debug + fmt::Display, B: Borrow<Buffer> + 'a> fmt::Display
 #[derive(Debug)]
 pub struct Record {
     pub inner: *mut htslib::bcf1_t,
-    header: Rc<HeaderView>,
+    header: Arc<HeaderView>,
 }
 
 impl Record {
     /// Construct record with reference to header `HeaderView`, for create-internal use.
-    pub(crate) fn new(header: Rc<HeaderView>) -> Self {
+    pub fn new(header: Arc<HeaderView>) -> Self {
         let inner = unsafe {
             let inner = htslib::bcf_init();
             // Always unpack record.
@@ -201,7 +201,7 @@ impl Record {
     }
 
     /// Set the record header.
-    pub(crate) fn set_header(&mut self, header: Rc<HeaderView>) {
+    pub(crate) fn set_header(&mut self, header: Arc<HeaderView>) {
         self.header = header;
     }
 

--- a/src/faidx/mod.rs
+++ b/src/faidx/mod.rs
@@ -195,6 +195,8 @@ impl Drop for Reader {
     }
 }
 
+unsafe impl Send for Reader {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This is an attempt to make the library a bit more usable in a multi-threaded setting. I started to replace `Rc<T>`s with `Arc<T>`s where the wrapper type is supposed to be Send and/or Sync [1]. Of course, since we work with raw C-pointers and `htslib` in the background, it is quite the task to _actually_ reason about thread-safety, so the assumption so far is that the C methods behave reasonable™. I need to mention that I am not very familiar with the underlying C code. So far, this PR also does not nearly solve all the problems related to thread-safety, frankly, it might introduce more. For example, I added Send/Sync implementations for some `Header` types, the soundness of which I have not really verified.

This all is motivated by the use of the library in my own multi-threaded program, and of course is therefore biased to what would be convenient for me (Send/Sync on Header or Reader/Writer types for example.) For getting a Send/Sync Reader/Writer, it is of course also possible to just create Wrapper types.

Maybe this will inspire some people to continue working on this, or I will do once I find the time. Maybe, this will even revive the discussion about how to solve this issue in general. I am very open to suggestions/discussions.

There are multiple issues that are mentioning this, most importantly maybe #293 .

[1] The performance penalty is, in my opinion, absolutely tolerable and greatly outweighs having to deal with segfault when doing something "simple" as using a parrallel iterator (.